### PR TITLE
Migrate to more ergonomic custom backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,15 +10,94 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "bytemuck"
-version = "1.21.0"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3"
+checksum = "b6b1fc10dbac614ebc03540c9dbd60e83887fda27794998c6528f1782047d540"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fa76293b4f7bb636ab88fd78228235b5248b4d05cc589aed610f954af5d7c7a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "crunchy"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
+
+[[package]]
+name = "darling"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "half"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
+dependencies = [
+ "bytemuck",
+ "cfg-if",
+ "crunchy",
+ "num-traits",
+]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "libm"
@@ -30,18 +109,21 @@ checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 name = "macerator"
 version = "0.1.0"
 dependencies = [
+ "bytemuck",
+ "half",
+ "macerator-macros",
+ "num-traits",
  "paste",
- "pulp",
 ]
 
 [[package]]
-name = "num-complex"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+name = "macerator-macros"
+version = "0.1.0"
 dependencies = [
- "bytemuck",
- "num-traits",
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -51,6 +133,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -60,27 +143,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
-name = "pulp"
-version = "0.21.5"
-source = "git+https://github.com/wingertge/pulp.git?rev=c550ba4eda98dcd964dc374fa4d508bfff9f03c8#c550ba4eda98dcd964dc374fa4d508bfff9f03c8"
+name = "proc-macro2"
+version = "1.0.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
 dependencies = [
- "bytemuck",
- "cfg-if",
- "libm",
- "num-complex",
- "paste",
- "reborrow",
- "version_check",
+ "unicode-ident",
 ]
 
 [[package]]
-name = "reborrow"
-version = "0.5.5"
+name = "quote"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03251193000f4bd3b042892be858ee50e8b3719f2b08e5833ac4353724632430"
+checksum = "c1f1914ce909e1658d9907913b4b91947430c7d9be598b15a1912935b8c04801"
+dependencies = [
+ "proc-macro2",
+]
 
 [[package]]
-name = "version_check"
-version = "0.9.5"
+name = "strsim"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "syn"
+version = "2.0.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02e925281e18ffd9d640e234264753c43edc62d64b2d4cf898f1bc5e75f3fc2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-edition = "2024"
+edition = "2021"
 name = "macerator"
 version = "0.1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,19 @@
 [package]
-edition = "2021"
+edition = "2024"
 name = "macerator"
 version = "0.1.0"
 
 [features]
 default = ["std"]
 
-std = ["pulp/std"]
+std = []
 
 [dependencies]
+bytemuck = { version = "1.22.0", features = ["aarch64_simd", "wasm_simd"] }
+half = { version = "2.4", features = ["bytemuck", "num-traits"] }
+macerator-macros = { version = "0.1.0", path = "crates/macerator-macros" }
+num-traits = "0.2.0"
 paste = "1"
-pulp = { git = "https://github.com/wingertge/pulp.git", rev = "c550ba4eda98dcd964dc374fa4d508bfff9f03c8", default-features = false }
-# pulp = { path = "../pulp/pulp" }
+
+[workspace]
+members = ["crates/macerator-macros"]

--- a/README.md
+++ b/README.md
@@ -1,16 +1,23 @@
 # Macerator
 
-A thin wrapper around [`pulp`](https://github.com/sarah-quinones/pulp) to provide type-generic SIMD
-operations using similar traits to the standard library. Currently based on a fork of pulp until
-necessary changes are merged.
+Originally a thin wrapper around [`pulp`](https://github.com/sarah-quinones/pulp) to provide type-generic SIMD
+operations using similar traits to the standard library, but now uses its own backend for more ergonomic
+type inference behaviour. Currently in an MVP state, with only operations and backends needed for
+[`burn`](https://github.com/tracel-ai/burn), which means no unstable features are currently used. This
+may change in the future, but it will likely keep following `burn` quite closely.
+
+## Backends
+
+Currently supports backends for `x86_64-v2`, `x86_64-v3`, `aarch64` and `wasm32`. More backends will
+be added when they're stabilized. Note that `wasm32` doesn't support runtime feature detection, so
+binary must be built with `target_feature=+simd128`.
 
 ## Example
 
 ```rust
-fn vclamp<S: Simd, T: VOrd>(simd: S, value: T::Vector<S>, min: T, max: T) -> T::Vector<S> {
+fn clamp<S: Simd, T: VOrd>(simd: S, value: Vector<S, T>, min: T, max: T) -> Vector<S, T> {
     let min = simd.splat(min);
     let max = simd.splat(max);
-    let v = T::vmin(value, max);
-    T::vmax(value, min)
+    value.min(max).max(min)
 }
 ```

--- a/crates/macerator-macros/Cargo.toml
+++ b/crates/macerator-macros/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-edition = "2024"
+edition = "2021"
 name = "macerator-macros"
 version = "0.1.0"
 

--- a/crates/macerator-macros/Cargo.toml
+++ b/crates/macerator-macros/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+edition = "2024"
+name = "macerator-macros"
+version = "0.1.0"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+darling = "0.20.10"
+proc-macro2 = "1.0.69"
+quote = "1.0.33"
+syn = { version = "2.0.39", features = ["full"] }

--- a/crates/macerator-macros/src/lib.rs
+++ b/crates/macerator-macros/src/lib.rs
@@ -1,0 +1,121 @@
+use darling::FromMeta;
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
+use syn::Expr;
+use syn::parse_quote;
+use syn::{FnArg, GenericParam, ItemFn, Pat, spanned::Spanned};
+
+#[derive(FromMeta, Default)]
+#[darling(default)]
+struct WithSimdOpts {
+    #[darling(default)]
+    arch: Option<Expr>,
+}
+
+#[proc_macro_attribute]
+pub fn with_simd(
+    attr: proc_macro::TokenStream,
+    item: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    match with_simd_impl(attr.into(), item.into()) {
+        Ok(out) => out.into(),
+        Err(e) => e.into_compile_error().into(),
+    }
+}
+
+fn with_simd_impl(attr: TokenStream, item: TokenStream) -> Result<TokenStream, syn::Error> {
+    let opts = match attr.is_empty() {
+        true => WithSimdOpts::default(),
+        false => {
+            let meta = syn::parse2::<syn::Meta>(attr)?;
+            WithSimdOpts::from_meta(&meta)?
+        }
+    };
+
+    let arch = opts.arch.unwrap_or(parse_quote!(::macerator::Arch::new()));
+    let func = syn::parse2::<syn::ItemFn>(item)?;
+
+    let ItemFn {
+        attrs,
+        vis,
+        sig,
+        block,
+    } = func.clone();
+
+    let name = &sig.ident;
+
+    let lifetimes = sig.generics.lifetimes();
+    let type_params = sig.generics.type_params();
+    let const_params = sig.generics.const_params();
+
+    let mut outer_fn_sig = sig.clone();
+    outer_fn_sig.generics.params = lifetimes
+        .map(|l| GenericParam::Lifetime(l.clone()))
+        .chain(type_params.skip(1).map(|t| GenericParam::Type(t.clone())))
+        .chain(const_params.map(|c| GenericParam::Const(c.clone())))
+        .collect();
+    let mut inner_fn_sig = sig.clone();
+    inner_fn_sig.ident = format_ident!("{}_impl", name);
+    let struct_name = format_ident!("{}_struct", name);
+
+    let fields = sig
+        .inputs
+        .iter()
+        .map(|arg| match arg {
+            FnArg::Receiver(_) => Err(syn::Error::new(arg.span(), "Can't use macro on methods")),
+            FnArg::Typed(pat_type) => {
+                let ident = match &*pat_type.pat {
+                    Pat::Ident(pat_ident) => &pat_ident.ident,
+                    _ => todo!(),
+                };
+                let ty = &*pat_type.ty;
+                Ok((ident, ty))
+            }
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let output_ty = match sig.output.clone() {
+        syn::ReturnType::Default => quote! { () },
+        syn::ReturnType::Type(_, ty) => quote! { #ty },
+    };
+
+    let inner_name = &inner_fn_sig.ident;
+    let (impl_generics, type_generics, where_clause) = outer_fn_sig.generics.split_for_impl();
+    let field_decl = fields.iter().map(|(ident, ty)| quote![#ident: #ty]);
+    let field_names = fields.iter().map(|it| it.0).collect::<Vec<_>>();
+
+    let simd_generic_name = sig.generics.type_params().next().unwrap().ident.clone();
+    let (_, inner_generics, _) = inner_fn_sig.generics.split_for_impl();
+    let turbofish = inner_generics.as_turbofish();
+    let struct_turbofish = type_generics.as_turbofish();
+
+    Ok(quote! {
+        #(#attrs)*
+        #vis #outer_fn_sig {
+            #[allow(non_camel_case_types)]
+            struct #struct_name #impl_generics #where_clause {
+                #(#field_decl,)*
+            };
+
+            impl #impl_generics ::macerator::WithSimd for #struct_name #type_generics #where_clause {
+                type Output = #output_ty;
+
+                #[inline(always)]
+                fn with_simd<#simd_generic_name: ::macerator::Simd>(self) -> <Self as ::macerator::WithSimd>::Output {
+                    let Self {
+                        #(#field_names,)*
+                    } = self;
+                    #[allow(unused_unsafe)]
+                    unsafe {
+                        #inner_name #turbofish(#(#field_names,)*)
+                    }
+                }
+            }
+
+            (#arch).dispatch( #struct_name #struct_turbofish { #(#field_names,)* } )
+        }
+
+        #(#attrs)*
+        #inner_fn_sig #block
+    })
+}

--- a/src/arithmetic.rs
+++ b/src/arithmetic.rs
@@ -1,86 +1,103 @@
 use core::ops::{Add, Div, Mul, Sub};
 
+use half::f16;
 use paste::paste;
-use pulp::Simd;
 
-use crate::Vectorizable;
-
-pub trait VAdd: Vectorizable + Add<Output = Self> {
-    fn vadd<S: Simd>(simd: S, lhs: Self::Vector<S>, rhs: Self::Vector<S>) -> Self::Vector<S>;
-}
-
-pub trait VSub: Vectorizable + Sub<Output = Self> {
-    fn vsub<S: Simd>(simd: S, lhs: Self::Vector<S>, rhs: Self::Vector<S>) -> Self::Vector<S>;
-}
-
-pub trait VMul: Vectorizable + Mul<Output = Self> {
-    fn vmul<S: Simd>(simd: S, lhs: Self::Vector<S>, rhs: Self::Vector<S>) -> Self::Vector<S>;
-}
-
-pub trait VDiv: Vectorizable + Div<Output = Self> {
-    fn vdiv<S: Simd>(simd: S, lhs: Self::Vector<S>, rhs: Self::Vector<S>) -> Self::Vector<S>;
-}
-
-pub trait VMulAdd: Vectorizable + Div<Output = Self> + Add<Output = Self> {
-    fn vmuladd<S: Simd>(
-        simd: S,
-        a: Self::Vector<S>,
-        b: Self::Vector<S>,
-        c: Self::Vector<S>,
-    ) -> Self::Vector<S>;
-}
+use crate::{
+    Scalar,
+    backend::{Simd, Vector},
+};
 
 macro_rules! impl_arith {
-    ($trait: ident, $name: ident, $ty: ty) => {
-        paste! {
-            impl $trait for $ty {
-                fn [<$trait:lower>]<S: Simd>(simd: S, lhs: Self::Vector<S>, rhs: Self::Vector<S>) -> Self::Vector<S> {
-                    simd.[<$name _ $ty s>](lhs, rhs)
+    ($trait: ident, $std_trait: path, $name: ident, $($ty: ty),*) => {
+        paste!{
+            pub trait $trait: Scalar + $std_trait<Output = Self> {
+                fn [<$trait:lower>]<S: Simd>(lhs: Vector<S, Self>, rhs: Vector<S, Self>) -> Vector<S, Self>;
+                fn is_accelerated<S: Simd>() -> bool;
+            }
+            $(impl $trait for $ty {
+                #[inline(always)]
+                fn [<$trait:lower>]<S: Simd>(lhs: Vector<S, Self>, rhs: Vector<S, Self>) -> Vector<S, Self> {
+                    S::typed(S::[<$name _ $ty>](*lhs, *rhs))
+                }
+                #[inline(always)]
+                fn is_accelerated<S: Simd>() -> bool {
+                    S::[<$name _ $ty _supported>]()
+                }
+            })*
+            impl<S: Simd, T: $trait> $std_trait<Self> for Vector<S, T> {
+                type Output = Self;
+
+                #[inline(always)]
+                fn $name(self, rhs: Self) -> Self::Output {
+                    T::[<$trait:lower>](self, rhs)
+                }
+            }
+            impl<S: Simd, T: $trait> ::core::ops::[<$std_trait Assign>]<Self> for Vector<S, T> {
+                #[inline(always)]
+                fn [<$name _assign>](&mut self, rhs: Self) {
+                    *self = T::[<$trait:lower>](*self, rhs)
                 }
             }
         }
     };
-    ($trait: ident, $name: ident, $($ty: ty),*) => {
-        $(impl_arith!($trait, $name, $ty);)*
+}
+
+impl_arith!(
+    VAdd, Add, add, u8, i8, u16, i16, u32, i32, u64, i64, f16, f32, f64
+);
+impl_arith!(
+    VSub, Sub, sub, u8, i8, u16, i16, u32, i32, u64, i64, f16, f32, f64
+);
+impl_arith!(VDiv, Div, div, f16, f32, f64);
+impl_arith!(VMul, Mul, mul, u16, i16, f16, u32, i32, f32, f64);
+
+pub trait VMulAdd: Scalar + Mul<Output = Self> + Add<Output = Self> {
+    fn vmul_add<S: Simd>(
+        a: Vector<S, Self>,
+        b: Vector<S, Self>,
+        c: Vector<S, Self>,
+    ) -> Vector<S, Self>;
+    fn is_accelerated<S: Simd>() -> bool;
+}
+
+impl<S: Simd, T: VMulAdd> Vector<S, T> {
+    #[inline(always)]
+    pub fn mul_add(self, b: Self, c: Self) -> Self {
+        T::vmul_add(self, b, c)
     }
 }
 
-impl_arith!(VAdd, add, u8, i8, u16, i16, u32, i32, u64, i64, f32, f64);
-impl_arith!(VSub, sub, u8, i8, u16, i16, u32, i32, u64, i64, f32, f64);
-impl_arith!(VMul, mul, u16, i16, u32, i32, f32, f64);
-impl_arith!(VDiv, div, f32, f64);
-
-macro_rules! vmuladd_impl {
-    (intrinsic $($ty: ty),*) => {
-        $(paste! {
-            impl VMulAdd for $ty {
-                fn vmuladd<S: Simd>(
-                    simd: S,
-                    a: Self::Vector<S>,
-                    b: Self::Vector<S>,
-                    c: Self::Vector<S>,
-                ) -> Self::Vector<S> {
-                    simd.[<mul_add_ $ty s>](a, b, c)
-                }
-            }
-        })*
-    };
+macro_rules! impl_mul_add {
     (fallback $($ty: ty),*) => {
-        $(paste! {
-            impl VMulAdd for $ty {
-                fn vmuladd<S: Simd>(
-                    simd: S,
-                    a: Self::Vector<S>,
-                    b: Self::Vector<S>,
-                    c: Self::Vector<S>,
-                ) -> Self::Vector<S> {
-                    let mul = simd.[<mul_ $ty s>](a, b);
-                    simd.[<add_ $ty s>](mul, c)
+        paste!{
+            $(impl VMulAdd for $ty {
+                #[inline(always)]
+                fn vmul_add<S: Simd>(a: Vector<S, Self>, b: Vector<S, Self>, c: Vector<S, Self>) -> Vector<S, Self> {
+                    S::typed(S::[<add_ $ty>](S::[<mul_ $ty>](*a, *b), *c))
                 }
-            }
-        })*
+                #[inline(always)]
+                fn is_accelerated<S: Simd>() -> bool {
+                    S::[<mul_ $ty _supported>]() && S::[<add_ $ty _supported>]()
+                }
+            })*
+        }
+    };
+    (intrinsic $($ty: ty),*) => {
+        paste!{
+            $(impl VMulAdd for $ty {
+                #[inline(always)]
+                fn vmul_add<S: Simd>(a: Vector<S, Self>, b: Vector<S, Self>, c: Vector<S, Self>) -> Vector<S, Self> {
+                    S::typed(S::[<mul_add_ $ty>](*a, *b, *c))
+                }
+                #[inline(always)]
+                fn is_accelerated<S: Simd>() -> bool {
+                    S::[<mul_add_ $ty _supported>]()
+                }
+            })*
+        }
     };
 }
 
-vmuladd_impl!(intrinsic f32, f64);
-vmuladd_impl!(fallback u16, i16, u32, i32, u64, i64);
+impl_mul_add!(intrinsic f16, f32, f64);
+impl_mul_add!(fallback u16, i16, u32, i32, u64, i64);

--- a/src/backend/aarch64.rs
+++ b/src/backend/aarch64.rs
@@ -1,0 +1,359 @@
+use core::{
+    arch::aarch64::*,
+    ops::{Add, Div, Mul, Sub},
+};
+
+use half::f16;
+use num_traits::real::Real;
+use paste::paste;
+
+use crate::{Scalar, backend::arch::NullaryFnOnce, cast};
+
+use super::{Simd, VRegister, Vector, WithSimd, arch::impl_simd};
+
+impl VRegister for int8x16_t {}
+
+pub struct NeonFma;
+
+macro_rules! with_ty {
+    ($func: ident, i8) => {
+        paste!([<$func _s8>])
+    };
+    ($func: ident, i16) => {
+        paste!([<$func _s16>])
+    };
+    ($func: ident, i32) => {
+        paste!([<$func _s32>])
+    };
+    ($func: ident, i64) => {
+        paste!([<$func _s64>])
+    };
+    ($func: ident, $ty: ident) => {
+        paste!([<$func _ $ty>])
+    }
+}
+
+macro_rules! impl_binop {
+    ($func: ident, $intrinsic: ident, $($ty: ty),*) => {
+        $(paste! {
+            #[inline(always)]
+            fn [<$func _ $ty>](a: Self::Register, b: Self::Register) -> Self::Register {
+                cast!(with_ty!($intrinsic, $ty)(cast!(a), cast!(b)))
+            }
+            #[inline(always)]
+            fn [<$func _ $ty _supported>]() -> bool {
+                true
+            }
+        })*
+    };
+}
+
+macro_rules! impl_cmp {
+    ($func: ident, $intrinsic: ident, $($ty: ty),*) => {
+        $(paste! {
+            #[inline(always)]
+            fn [<$func _ $ty>](a: Self::Register, b: Self::Register) -> <$ty as Scalar>::Mask<Self> {
+                cast!(with_ty!($intrinsic, $ty)(cast!(a), cast!(b)))
+            }
+            #[inline(always)]
+            fn [<$func _ $ty _supported>]() -> bool {
+                true
+            }
+        })*
+    };
+}
+
+macro_rules! impl_unop {
+    ($func: ident, $intrinsic: ident, $($ty: ty),*) => {
+        $(paste! {
+            #[inline(always)]
+            fn [<$func _ $ty>](a: Self::Register) -> Self::Register {
+                cast!(with_ty!($intrinsic, $ty)(cast!(a)))
+            }
+            #[inline(always)]
+            fn [<$func _ $ty _supported>]() -> bool {
+                true
+            }
+        })*
+    };
+}
+
+macro_rules! impl_binop_scalar {
+    ($func: ident, $intrinsic: path, $($ty: ty),*) => {
+        $(paste! {
+            #[inline(always)]
+            fn [<$func _ $ty>](a: Self::Register, b: Self::Register) -> Self::Register {
+                const LANES: usize = 16 / size_of::<$ty>();
+                let a: [$ty; LANES] = cast!(a);
+                let b: [$ty; LANES] = cast!(b);
+                let mut out = [$ty::default(); LANES];
+
+                for i in 0..LANES {
+                    out[i] = $intrinsic(a[i], b[i]);
+                }
+                cast!(out)
+            }
+            #[inline(always)]
+            fn [<$func _ $ty _supported>]() -> bool {
+                false
+            }
+        })*
+    };
+}
+
+macro_rules! lanes {
+    ($($bits: literal),*) => {
+        $(paste! {
+            #[inline(always)]
+            fn [<lanes $bits>]() -> usize {
+                128 / $bits
+            }
+        })*
+    };
+}
+
+impl Simd for NeonFma {
+    type Register = int8x16_t;
+    type Mask8 = Vector<Self, i8>;
+    type Mask16 = Vector<Self, i16>;
+    type Mask32 = Vector<Self, i32>;
+    type Mask64 = Vector<Self, i64>;
+
+    lanes!(8, 16, 32, 64);
+
+    impl_binop!(add, vaddq, u8, i8, u16, i16, u32, i32, f32, u64, i64, f64);
+    impl_binop!(sub, vsubq, u8, i8, u16, i16, u32, i32, f32, u64, i64, f64);
+    impl_binop!(mul, vmulq, u8, i8, u16, i16, u32, i32, f32, f64);
+    impl_binop!(div, vdivq, f32, f64);
+    impl_binop!(min, vminq, u8, i8, u16, i16, u32, i32, f32, f64);
+    impl_binop!(max, vmaxq, u8, i8, u16, i16, u32, i32, f32, f64);
+
+    impl_unop!(recip, vrecpeq, f32, f64);
+    impl_unop!(abs, vabsq, i8, i16, i32, i64, f32, f64);
+
+    impl_cmp!(
+        equals, vceqq, u8, i8, u16, i16, u32, i32, f32, u64, i64, f64
+    );
+    impl_cmp!(
+        less_than, vcltq, u8, i8, u16, i16, u32, i32, f32, u64, i64, f64
+    );
+    impl_cmp!(
+        less_than_or_equal,
+        vcleq,
+        u8,
+        i8,
+        u16,
+        i16,
+        u32,
+        i32,
+        f32,
+        u64,
+        i64,
+        f64
+    );
+    impl_cmp!(
+        greater_than,
+        vcgtq,
+        u8,
+        i8,
+        u16,
+        i16,
+        u32,
+        i32,
+        f32,
+        u64,
+        i64,
+        f64
+    );
+    impl_cmp!(
+        greater_than_or_equal,
+        vcgeq,
+        u8,
+        i8,
+        u16,
+        i16,
+        u32,
+        i32,
+        f32,
+        u64,
+        i64,
+        f64
+    );
+
+    impl_binop_scalar!(add, Add::add, f16);
+    impl_binop_scalar!(sub, Sub::sub, f16);
+    impl_binop_scalar!(mul, Mul::mul, f16, u64, i64);
+    impl_binop_scalar!(div, Div::div, f16);
+    impl_binop_scalar!(min, Ord::min, u64, i64);
+    impl_binop_scalar!(min, f16::min, f16);
+    impl_binop_scalar!(max, Ord::max, u64, i64);
+    impl_binop_scalar!(max, f16::max, f16);
+
+    fn vectorize<Op: WithSimd>(op: Op) -> Op::Output {
+        struct Impl<Op> {
+            op: Op,
+        }
+        impl<Op: WithSimd> NullaryFnOnce for Impl<Op> {
+            type Output = Op::Output;
+
+            #[inline(always)]
+            fn call(self) -> Self::Output {
+                self.op.with_simd::<NeonFma>()
+            }
+        }
+        Self::run_vectorized(Impl { op })
+    }
+
+    #[inline(always)]
+    unsafe fn load<T: Scalar>(ptr: *const T) -> super::Vector<Self, T> {
+        cast!(vld1q_s8(ptr as _))
+    }
+    #[inline(always)]
+    unsafe fn load_unaligned<T: Scalar>(ptr: *const T) -> super::Vector<Self, T> {
+        cast!(vld1q_s8(ptr as _))
+    }
+    #[inline(always)]
+    unsafe fn load_low<T: Scalar>(ptr: *const T) -> super::Vector<Self, T> {
+        cast!(vld1q_lane_s64::<0>(ptr as _, cast!(Self::splat_i64(0))))
+    }
+    #[inline(always)]
+    unsafe fn load_high<T: Scalar>(ptr: *const T) -> super::Vector<Self, T> {
+        cast!(vld1q_lane_s64::<1>(
+            (ptr as *const i64).add(i64::lanes::<Self>() / 2),
+            cast!(Self::splat_i64(0))
+        ))
+    }
+    #[inline(always)]
+    unsafe fn store<T: Scalar>(ptr: *mut T, value: super::Vector<Self, T>) {
+        unsafe { vst1q_s8(ptr as _, cast!(value)) };
+    }
+    #[inline(always)]
+    unsafe fn store_unaligned<T: Scalar>(ptr: *mut T, value: super::Vector<Self, T>) {
+        unsafe { vst1q_s8(ptr as _, cast!(value)) };
+    }
+    #[inline(always)]
+    unsafe fn store_low<T: Scalar>(ptr: *mut T, value: super::Vector<Self, T>) {
+        unsafe { vst1q_lane_s64::<0>(ptr as _, cast!(value)) };
+    }
+    #[inline(always)]
+    unsafe fn store_high<T: Scalar>(ptr: *mut T, value: super::Vector<Self, T>) {
+        unsafe {
+            vst1q_lane_s64::<1>(
+                (ptr as *mut i64).add(i64::lanes::<Self>() / 2),
+                cast!(value),
+            )
+        };
+    }
+    #[inline(always)]
+    fn splat_i8(value: i8) -> Self::Register {
+        cast!(vdupq_n_s8(value))
+    }
+    #[inline(always)]
+    fn splat_i16(value: i16) -> Self::Register {
+        cast!(vdupq_n_s16(value))
+    }
+    #[inline(always)]
+    fn splat_i32(value: i32) -> Self::Register {
+        cast!(vdupq_n_s32(value))
+    }
+    #[inline(always)]
+    fn splat_i64(value: i64) -> Self::Register {
+        cast!(vdupq_n_s64(value))
+    }
+    #[inline(always)]
+    fn bitand(a: Self::Register, b: Self::Register) -> Self::Register {
+        cast!(vandq_s8(a, b))
+    }
+    #[inline(always)]
+    fn bitand_supported() -> bool {
+        true
+    }
+    #[inline(always)]
+    fn bitor(a: Self::Register, b: Self::Register) -> Self::Register {
+        cast!(vorrq_s8(a, b))
+    }
+    #[inline(always)]
+    fn bitor_supported() -> bool {
+        true
+    }
+    #[inline(always)]
+    fn bitxor(a: Self::Register, b: Self::Register) -> Self::Register {
+        cast!(veorq_s8(a, b))
+    }
+    #[inline(always)]
+    fn bitxor_supported() -> bool {
+        true
+    }
+    #[inline(always)]
+    fn bitnot(a: Self::Register) -> Self::Register {
+        Self::bitxor(a, Self::splat_i64(-1))
+    }
+    #[inline(always)]
+    fn bitnot_supported() -> bool {
+        true
+    }
+    #[inline(always)]
+    fn mul_add_f16(a: Self::Register, b: Self::Register, c: Self::Register) -> Self::Register {
+        let a: [f16; 8] = cast!(a);
+        let b: [f16; 8] = cast!(b);
+        let c: [f16; 8] = cast!(c);
+        let mut out = [f16::default(); 8];
+
+        for i in 0..8 {
+            out[i] = a[i].mul_add(b[i], c[i]);
+        }
+        cast!(out)
+    }
+    #[inline(always)]
+    fn mul_add_f16_supported() -> bool {
+        false
+    }
+    #[inline(always)]
+    fn mul_add_f32(a: Self::Register, b: Self::Register, c: Self::Register) -> Self::Register {
+        cast!(vfmaq_f32(cast!(a), cast!(b), cast!(c)))
+    }
+    #[inline(always)]
+    fn mul_add_f32_supported() -> bool {
+        true
+    }
+    #[inline(always)]
+    fn mul_add_f64(a: Self::Register, b: Self::Register, c: Self::Register) -> Self::Register {
+        cast!(vfmaq_f64(cast!(a), cast!(b), cast!(c)))
+    }
+    #[inline(always)]
+    fn mul_add_f64_supported() -> bool {
+        true
+    }
+    #[inline(always)]
+    fn recip_f16(a: Self::Register) -> Self::Register {
+        let a: [f16; 8] = cast!(a);
+        let mut out = [f16::default(); 8];
+
+        for i in 0..8 {
+            out[i] = a[i].recip();
+        }
+        cast!(out)
+    }
+    #[inline(always)]
+    fn recip_f16_supported() -> bool {
+        false
+    }
+    #[inline(always)]
+    fn abs_f16(a: Self::Register) -> Self::Register {
+        let a: [f16; 8] = cast!(a);
+        let mut out = [f16::default(); 8];
+
+        for i in 0..8 {
+            out[i] = a[i].abs();
+        }
+        cast!(out)
+    }
+    #[inline(always)]
+    fn abs_f16_supported() -> bool {
+        false
+    }
+}
+
+impl NeonFma {
+    impl_simd!("neon");
+}

--- a/src/backend/arch.rs
+++ b/src/backend/arch.rs
@@ -1,0 +1,206 @@
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+mod x86;
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+pub use x86::*;
+
+#[cfg(target_arch = "aarch64")]
+mod aarch64;
+#[cfg(target_arch = "aarch64")]
+pub use aarch64::*;
+
+#[cfg(target_arch = "wasm32")]
+mod wasm32;
+#[cfg(target_arch = "wasm32")]
+pub use wasm32::*;
+
+#[cfg(not(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    target_arch = "wasm32"
+)))]
+#[derive(Debug, Clone, Copy)]
+#[non_exhaustive]
+#[repr(u8)]
+pub enum Arch {
+    Scalar,
+}
+
+#[cfg(not(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    target_arch = "wasm32"
+)))]
+impl Arch {
+    pub fn new() -> Self {
+        Self::Scalar
+    }
+
+    pub fn dispatch<Op: WithSimd>(self, op: Op) -> Op::Output {
+        match self {
+            Arch::Scalar => <Fallback as Simd>::vectorize(op),
+        }
+    }
+}
+
+#[cfg(not(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    target_arch = "wasm32"
+)))]
+impl Default for Arch {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(all(feature = "std", any(target_arch = "x86", target_arch = "x86_64")))]
+#[macro_export]
+macro_rules! feature_detected {
+    ($feature: tt) => {
+        ::std::is_x86_feature_detected!($feature)
+    };
+}
+
+#[cfg(all(feature = "std", target_arch = "aarch64"))]
+#[macro_export]
+macro_rules! feature_detected {
+    ($feature: tt) => {
+        ::std::arch::is_aarch64_feature_detected!($feature)
+    };
+}
+
+#[cfg(any(
+    not(feature = "std"),
+    not(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"))
+))]
+#[macro_export]
+macro_rules! feature_detected {
+    ($feature: tt) => {
+        cfg!(target_feature = $feature)
+    };
+}
+#[allow(unused)]
+pub(crate) use feature_detected;
+
+macro_rules! impl_simd {
+    ($($feature: tt),*) => {
+        #[inline(always)]
+        pub(crate) fn __static_available() -> &'static ::core::sync::atomic::AtomicU8 {
+            static AVAILABLE: ::core::sync::atomic::AtomicU8 =
+                ::core::sync::atomic::AtomicU8::new(u8::MAX);
+            &AVAILABLE
+        }
+
+        /// Returns `true` if the required CPU features for this type are available,
+        /// otherwise returns `false`.
+        #[inline]
+        pub fn is_available() -> bool {
+            let mut available =
+                Self::__static_available().load(::core::sync::atomic::Ordering::Relaxed);
+            if available == u8::MAX {
+                available = Self::__detect_is_available() as u8;
+            }
+            available != 0
+        }
+
+        #[inline(never)]
+        fn __detect_is_available() -> bool {
+            let out = true $(&& $crate::backend::arch::feature_detected!($feature))*;
+            Self::__static_available().store(out as u8, ::core::sync::atomic::Ordering::Relaxed);
+            out
+        }
+
+        /// Vectorizes the given function as if the CPU features for this type were
+    /// applied to it.
+    ///
+    /// # Note
+    /// For the vectorization to work properly, the given function must be
+    /// inlined. Consider marking it as `#[inline(always)]`
+    #[inline(always)]
+    pub fn run_vectorized<F: NullaryFnOnce>(f: F) -> F::Output {
+        $(#[target_feature(enable = $feature)])*
+        #[inline]
+        #[allow(clippy::too_many_arguments)]
+        unsafe fn imp_fastcall<F: NullaryFnOnce>(
+            f0: ::core::mem::MaybeUninit<::core::primitive::usize>,
+            f1: ::core::mem::MaybeUninit<::core::primitive::usize>,
+            f2: ::core::mem::MaybeUninit<::core::primitive::usize>,
+            f3: ::core::mem::MaybeUninit<::core::primitive::usize>,
+            f4: ::core::mem::MaybeUninit<::core::primitive::usize>,
+            f5: ::core::mem::MaybeUninit<::core::primitive::usize>,
+            f6: ::core::mem::MaybeUninit<::core::primitive::usize>,
+            f7: ::core::mem::MaybeUninit<::core::primitive::usize>,
+        ) -> F::Output {
+            let f: F = unsafe { core::mem::transmute_copy(&[f0, f1, f2, f3, f4, f5, f6, f7]) };
+            f.call()
+        }
+        $(#[target_feature(enable = $feature)])*
+        #[inline]
+        unsafe fn imp<F: NullaryFnOnce>(f: F) -> F::Output {
+            f.call()
+        }
+        if const {
+            (::core::mem::size_of::<F>() <= 8 * ::core::mem::size_of::<::core::primitive::usize>())
+        } {
+            union Pad<T> {
+                t: ::core::mem::ManuallyDrop<T>,
+                __u: ::core::mem::MaybeUninit<[usize; 8]>,
+            }
+            let f = Pad {
+                t: ::core::mem::ManuallyDrop::new(f),
+            };
+            let p = (&f) as *const _ as *const ::core::mem::MaybeUninit<usize>;
+            unsafe {
+                imp_fastcall::<F>(
+                    *p.add(0),
+                    *p.add(1),
+                    *p.add(2),
+                    *p.add(3),
+                    *p.add(4),
+                    *p.add(5),
+                    *p.add(6),
+                    *p.add(7),
+                )
+            }
+        } else {
+            unsafe { imp(f) }
+        }
+    }
+    };
+}
+pub(crate) use impl_simd;
+
+use super::Simd;
+
+pub trait NullaryFnOnce {
+    type Output;
+
+    fn call(self) -> Self::Output;
+}
+
+impl<R, F: FnOnce() -> R> NullaryFnOnce for F {
+    type Output = R;
+
+    #[inline(always)]
+    fn call(self) -> Self::Output {
+        self()
+    }
+}
+
+pub trait WithSimd {
+    type Output;
+
+    fn with_simd<S: Simd>(self) -> Self::Output;
+}
+
+impl<F: NullaryFnOnce> WithSimd for F {
+    type Output = F::Output;
+
+    #[inline(always)]
+    fn with_simd<S: Simd>(self) -> Self::Output {
+        self.call()
+    }
+}

--- a/src/backend/arch/aarch64.rs
+++ b/src/backend/arch/aarch64.rs
@@ -1,0 +1,37 @@
+use crate::{
+    Simd,
+    backend::{aarch64::NeonFma, scalar::Fallback},
+};
+
+use super::WithSimd;
+
+#[derive(Debug, Clone, Copy)]
+#[non_exhaustive]
+#[repr(u8)]
+pub enum Arch {
+    Scalar,
+    NeonFma,
+}
+
+impl Arch {
+    pub fn new() -> Self {
+        if NeonFma::is_available() {
+            Self::NeonFma
+        } else {
+            Self::Scalar
+        }
+    }
+
+    pub fn dispatch<Op: WithSimd>(self, op: Op) -> Op::Output {
+        match self {
+            Arch::Scalar => <Fallback as Simd>::vectorize(op),
+            Arch::NeonFma => <NeonFma as Simd>::vectorize(op),
+        }
+    }
+}
+
+impl Default for Arch {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/backend/arch/wasm32.rs
+++ b/src/backend/arch/wasm32.rs
@@ -1,0 +1,37 @@
+use crate::{
+    Simd,
+    backend::{scalar::Fallback, wasm32::Simd128},
+};
+
+use super::WithSimd;
+
+#[derive(Debug, Clone, Copy)]
+#[non_exhaustive]
+#[repr(u8)]
+pub enum Arch {
+    Scalar,
+    Simd128,
+}
+
+impl Arch {
+    pub fn new() -> Self {
+        if Simd128::is_available() {
+            Self::Simd128
+        } else {
+            Self::Scalar
+        }
+    }
+
+    pub fn dispatch<Op: WithSimd>(self, op: Op) -> Op::Output {
+        match self {
+            Arch::Scalar => <Fallback as Simd>::vectorize(op),
+            Arch::Simd128 => <Simd128 as Simd>::vectorize(op),
+        }
+    }
+}
+
+impl Default for Arch {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/backend/arch/x86.rs
+++ b/src/backend/arch/x86.rs
@@ -1,0 +1,41 @@
+use crate::{
+    Simd,
+    backend::{scalar::Fallback, x86::v2::V2, x86::v3::V3},
+};
+
+use super::WithSimd;
+
+#[derive(Debug, Clone, Copy)]
+#[non_exhaustive]
+#[repr(u8)]
+pub enum Arch {
+    Scalar,
+    V2,
+    V3,
+}
+
+impl Arch {
+    pub fn new() -> Self {
+        if V3::is_available() {
+            Self::V3
+        } else if V2::is_available() {
+            Self::V2
+        } else {
+            Self::Scalar
+        }
+    }
+
+    pub fn dispatch<Op: WithSimd>(self, op: Op) -> Op::Output {
+        match self {
+            Arch::Scalar => <Fallback as Simd>::vectorize(op),
+            Arch::V2 => <V2 as Simd>::vectorize(op),
+            Arch::V3 => <V3 as Simd>::vectorize(op),
+        }
+    }
+}
+
+impl Default for Arch {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1,0 +1,295 @@
+#![allow(
+    clippy::transmute_float_to_int,
+    unused_unsafe,
+    clippy::useless_transmute,
+    clippy::missing_transmute_annotations
+)]
+
+use bytemuck::{CheckedBitPattern, NoUninit, Pod, Zeroable};
+use core::{fmt::Debug, marker::PhantomData, ops::Deref};
+use half::{bf16, f16};
+use paste::paste;
+
+mod arch;
+mod scalar;
+pub use arch::{Arch, WithSimd};
+#[cfg(target_arch = "aarch64")]
+mod aarch64;
+#[cfg(target_arch = "wasm32")]
+mod wasm32;
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+mod x86;
+
+use crate::{Scalar, VAdd};
+
+pub trait VRegister: Copy + Pod + Debug {}
+
+macro_rules! cast {
+    ($v: expr) => {
+        unsafe { core::mem::transmute($v) }
+    };
+}
+pub(crate) use cast;
+
+#[repr(C)]
+pub struct Vector<S: Simd, T: Scalar> {
+    inner: S::Register,
+    _ty: PhantomData<T>,
+}
+
+impl<S: Simd, T: Scalar> Clone for Vector<S, T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl<S: Simd, T: Scalar> Copy for Vector<S, T> {}
+impl<S: Simd, T: Scalar> Debug for Vector<S, T> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_tuple("Vector").field(&self.inner).finish()
+    }
+}
+
+unsafe impl<S: Simd, T: Scalar> Pod for Vector<S, T> {}
+unsafe impl<S: Simd, T: Scalar> Zeroable for Vector<S, T> {}
+
+impl<S: Simd, T: Scalar> Deref for Vector<S, T> {
+    type Target = S::Register;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+macro_rules! declare_binop {
+    ($name: ident, $($ty: ty),*) => {
+        $(paste! {
+            fn [<$name _ $ty>](a: Self::Register, b: Self::Register) -> Self::Register;
+            fn [<$name _ $ty _supported>]() -> bool;
+        })*
+    };
+}
+
+macro_rules! declare_unop {
+    ($name: ident, $($ty: ty),*) => {
+        $(paste! {
+            fn [<$name _ $ty>](a: Self::Register) -> Self::Register;
+            fn [<$name _ $ty _supported>]() -> bool;
+        })*
+    };
+}
+
+macro_rules! declare_cmp {
+    ($name: ident, $($ty: ty),*) => {
+        $(paste! {
+            fn [<$name _ $ty>](a: Self::Register, b: Self::Register) -> <$ty as Scalar>::Mask<Self>;
+            fn [<$name _ $ty _supported>]() -> bool;
+        })*
+    };
+}
+
+macro_rules! splat {
+    (float $($bits: literal),*) => {
+        $(paste!{
+            fn [<splat_i $bits>](value: [<i $bits>]) -> Self::Register;
+            splat!(transmute $bits -> [<u $bits>]);
+            splat!(transmute $bits -> [<f $bits>]);
+        })*
+    };
+    (transmute $bits: literal -> $ty: ident) => {
+        paste! {
+            fn [<splat_ $ty>](value: $ty) -> Self::Register {
+                Self::[<splat_i $bits>](unsafe { core::mem::transmute::<$ty, [<i $bits>]>(value) })
+            }
+        }
+    };
+}
+
+pub trait Simd: Sized + 'static {
+    type Register: VRegister;
+    type Mask8: Debug + Copy + Send + Sync + Zeroable + NoUninit + CheckedBitPattern + 'static;
+    type Mask16: Debug + Copy + Send + Sync + Zeroable + NoUninit + CheckedBitPattern + 'static;
+    type Mask32: Debug + Copy + Send + Sync + Zeroable + NoUninit + CheckedBitPattern + 'static;
+    type Mask64: Debug + Copy + Send + Sync + Zeroable + NoUninit + CheckedBitPattern + 'static;
+
+    fn lanes8() -> usize;
+    fn lanes16() -> usize;
+    fn lanes32() -> usize;
+    fn lanes64() -> usize;
+
+    fn typed<T: Scalar>(reg: Self::Register) -> Vector<Self, T> {
+        Vector {
+            inner: reg,
+            _ty: PhantomData,
+        }
+    }
+    fn vectorize<Op: WithSimd>(op: Op) -> Op::Output;
+
+    /// Load a vector from an aligned element pointer. Must be aligned to the
+    /// whole vector.
+    ///
+    /// # Safety
+    ///
+    /// Same safety requirements as [`read`](std::ptr::read), with the
+    /// additional requirement that the entire vector must be aligned and
+    /// valid, not just the element at `ptr`.
+    unsafe fn load<T: Scalar>(ptr: *const T) -> Vector<Self, T>;
+    /// Load a vector from an unaligned element pointer.
+    ///
+    /// # Safety
+    ///
+    /// Same safety requirements as
+    /// [`read_unaligned`](std::ptr::read_unaligned), with the additional
+    /// requirement that the entire vector must be valid, not just the
+    /// element at `ptr`.
+    unsafe fn load_unaligned<T: Scalar>(ptr: *const T) -> Vector<Self, T>;
+    /// Load the lower half of a vector from an unaligned element pointer.
+    ///
+    /// # Safety
+    ///
+    /// Same safety requirements as
+    /// [`read_unaligned`](std::ptr::read_unaligned), with the additional
+    /// requirement that the lower half of the vector must be valid, not just
+    /// the element at `ptr`.
+    unsafe fn load_low<T: Scalar>(ptr: *const T) -> Vector<Self, T>;
+    /// Load the upper half of a vector from an unaligned element pointer.
+    ///
+    /// # Safety
+    ///
+    /// Same safety requirements as
+    /// [`read_unaligned`](std::ptr::read_unaligned), with the additional
+    /// requirement that the upper half of the vector must be valid, not just
+    /// the element at `ptr`.
+    unsafe fn load_high<T: Scalar>(ptr: *const T) -> Vector<Self, T>;
+    /// Store the lower half of a vector to an aligned element pointer. Must be
+    /// aligned to the whole vector.
+    ///
+    /// # Safety
+    ///
+    /// Same safety requirements as
+    /// [`write`](std::ptr::write), with the additional
+    /// requirement that the entire vector must be valid and aligned to the size
+    /// of the full vectgor, not just the element at `ptr`.
+    unsafe fn store<T: Scalar>(ptr: *mut T, value: Vector<Self, T>);
+    /// Store the upper half of a vector to an unaligned element pointer.
+    ///
+    /// # Safety
+    ///
+    /// Same safety requirements as
+    /// [`write_unaligned`](std::ptr::write_unaligned), with the additional
+    /// requirement that the entire vector must be valid, not just
+    /// the element at `ptr`.
+    unsafe fn store_unaligned<T: Scalar>(ptr: *mut T, value: Vector<Self, T>);
+    /// Store the upper half of a vector to an unaligned element pointer.
+    ///
+    /// # Safety
+    ///
+    /// Same safety requirements as
+    /// [`write_unaligned`](std::ptr::write_unaligned), with the additional
+    /// requirement that the lower half of the vector must be valid, not just
+    /// the element at `ptr`.
+    unsafe fn store_low<T: Scalar>(ptr: *mut T, value: Vector<Self, T>);
+    /// Store the upper half of a vector to an unaligned element pointer.
+    ///
+    /// # Safety
+    ///
+    /// Same safety requirements as
+    /// [`write_unaligned`](std::ptr::write_unaligned), with the additional
+    /// requirement that the upper half of the vector must be valid, not just
+    /// the element at `ptr`.
+    unsafe fn store_high<T: Scalar>(ptr: *mut T, value: Vector<Self, T>);
+
+    fn splat_i8(value: i8) -> Self::Register;
+    splat!(transmute 8 -> u8);
+    splat!(transmute 16 -> bf16);
+    splat!(float 16, 32, 64);
+
+    fn add<T: VAdd>(a: Vector<Self, T>, b: Vector<Self, T>) -> Vector<Self, T> {
+        T::vadd::<Self>(a, b)
+    }
+
+    declare_binop!(add, i8, u8, i16, u16, i32, u32, i64, u64, f16, f32, f64);
+    declare_binop!(sub, i8, u8, i16, u16, f16, i32, u32, i64, u64, f32, f64);
+    declare_binop!(div, f16, f32, f64);
+    declare_binop!(mul, i8, u8, i16, u16, f16, i32, u32, f32, u64, i64, f64);
+    declare_binop!(min, u8, i8, u16, i16, f16, u32, i32, f32, u64, i64, f64);
+    declare_binop!(max, u8, i8, u16, i16, f16, u32, i32, f32, u64, i64, f64);
+
+    fn bitand(a: Self::Register, b: Self::Register) -> Self::Register;
+    fn bitand_supported() -> bool;
+    fn bitor(a: Self::Register, b: Self::Register) -> Self::Register;
+    fn bitor_supported() -> bool;
+    fn bitxor(a: Self::Register, b: Self::Register) -> Self::Register;
+    fn bitxor_supported() -> bool;
+    fn bitnot(a: Self::Register) -> Self::Register;
+    fn bitnot_supported() -> bool;
+
+    declare_cmp!(equals, i8, u8, i16, u16, i32, u32, f32, i64, u64, f64);
+    declare_cmp!(less_than, i8, u8, i16, u16, i32, u32, f32, i64, u64, f64);
+    declare_cmp!(
+        less_than_or_equal,
+        i8,
+        u8,
+        i16,
+        u16,
+        i32,
+        u32,
+        f32,
+        i64,
+        u64,
+        f64
+    );
+    declare_cmp!(greater_than, i8, u8, i16, u16, i32, u32, f32, i64, u64, f64);
+    declare_cmp!(
+        greater_than_or_equal,
+        i8,
+        u8,
+        i16,
+        u16,
+        i32,
+        u32,
+        f32,
+        i64,
+        u64,
+        f64
+    );
+
+    fn mul_add_f16(a: Self::Register, b: Self::Register, c: Self::Register) -> Self::Register;
+    fn mul_add_f16_supported() -> bool;
+    fn mul_add_f32(a: Self::Register, b: Self::Register, c: Self::Register) -> Self::Register;
+    fn mul_add_f32_supported() -> bool;
+    fn mul_add_f64(a: Self::Register, b: Self::Register, c: Self::Register) -> Self::Register;
+    fn mul_add_f64_supported() -> bool;
+
+    declare_unop!(recip, f16, f32, f64);
+    declare_unop!(abs, i8, i16, i32, i64, f16, f32, f64);
+}
+
+/// Tests that type inference works properly
+#[cfg(test)]
+mod test_inference {
+    use core::ptr::null;
+
+    use crate::{
+        Scalar, VAdd,
+        backend::{Simd, Vector},
+        vload,
+    };
+
+    #[allow(unused)]
+    fn simd_splat<S: Simd, T: Scalar>() -> Vector<S, T> {
+        let value = T::default();
+        value.splat()
+    }
+
+    #[allow(unused)]
+    fn load<S: Simd, T: Scalar>() -> Vector<S, T> {
+        unsafe { vload(null()) }
+    }
+
+    #[allow(unused)]
+    fn add<S: Simd, T: VAdd>() -> Vector<S, T> {
+        let a = T::default().splat();
+        let b = T::default().splat();
+        a + b
+    }
+}

--- a/src/backend/scalar.rs
+++ b/src/backend/scalar.rs
@@ -1,0 +1,342 @@
+#![allow(clippy::transmute_num_to_bytes)]
+
+use core::{
+    ops::{Add, BitAnd, BitOr, BitXor, Div, Mul, Sub},
+    ptr::{read, read_unaligned, write, write_unaligned},
+};
+
+use half::f16;
+use num_traits::Float;
+use paste::paste;
+
+use crate::Scalar;
+
+use super::{Simd, VRegister, WithSimd, cast};
+
+impl VRegister for u64 {}
+
+pub struct Fallback;
+
+macro_rules! impl_binop_scalar {
+    ($func: ident, $intrinsic: path, $($ty: ty),*) => {
+        $(paste! {
+            #[inline(always)]
+            fn [<$func _ $ty>](a: Self::Register, b: Self::Register) -> Self::Register {
+                const LANES: usize = 8 / size_of::<$ty>();
+                let a: [$ty; LANES] = cast!(a);
+                let b: [$ty; LANES] = cast!(b);
+                let mut out = [$ty::default(); LANES];
+
+                for i in 0..LANES {
+                    out[i] = $intrinsic(a[i], b[i]);
+                }
+                cast!(out)
+            }
+            #[inline(always)]
+            fn [<$func _ $ty _supported>]() -> bool {
+                false
+            }
+        })*
+    };
+}
+
+macro_rules! impl_unop_scalar {
+    ($func: ident, $intrinsic: path, $($ty: ty),*) => {
+        $(paste! {
+            #[inline(always)]
+            fn [<$func _ $ty>](a: Self::Register) -> Self::Register {
+                const LANES: usize = 8 / size_of::<$ty>();
+                let a: [$ty; LANES] = cast!(a);
+                let mut out = [$ty::default(); LANES];
+
+                for i in 0..LANES {
+                    out[i] = a[i].$intrinsic();
+                }
+                cast!(out)
+            }
+            #[inline(always)]
+            fn [<$func _ $ty _supported>]() -> bool {
+                false
+            }
+        })*
+    };
+}
+
+macro_rules! impl_binop_scalar_full {
+    ($func: ident, $intrinsic: path) => {
+        paste! {
+            #[inline(always)]
+            fn [<$func>](a: Self::Register, b: Self::Register) -> Self::Register {
+                $intrinsic(a, b)
+            }
+            #[inline(always)]
+            fn [<$func _supported>]() -> bool {
+                false
+            }
+        }
+    };
+}
+
+macro_rules! impl_cmp_scalar {
+    ($func: ident, $intrinsic: path, $($ty: ty),*) => {
+        $(paste! {
+            #[inline(always)]
+            fn [<$func _ $ty>](a: Self::Register, b: Self::Register) -> <$ty as Scalar>::Mask<Self> {
+                const LANES: usize = 8 / size_of::<$ty>();
+                let a: [$ty; LANES] = cast!(a);
+                let b: [$ty; LANES] = cast!(b);
+                let mut out = [0u8; LANES];
+
+                for i in 0..LANES {
+                    out[i] = a[i].$intrinsic(&b[i]) as u8;
+                }
+                cast!(out)
+            }
+            #[inline(always)]
+            fn [<$func _ $ty _supported>]() -> bool {
+                false
+            }
+        })*
+    };
+}
+
+macro_rules! lanes {
+    ($($bits: literal),*) => {
+        $(paste! {
+            #[inline(always)]
+            fn [<lanes $bits>]() -> usize {
+                64 / $bits
+            }
+        })*
+    };
+}
+
+impl Simd for Fallback {
+    type Register = u64;
+    type Mask8 = [u8; 8];
+    type Mask16 = [u8; 4];
+    type Mask32 = [u8; 2];
+    type Mask64 = [u8; 1];
+
+    lanes!(8, 16, 32, 64);
+
+    impl_binop_scalar!(
+        add,
+        Add::add,
+        u8,
+        i8,
+        u16,
+        i16,
+        f16,
+        u32,
+        i32,
+        f32,
+        u64,
+        i64,
+        f64
+    );
+    impl_binop_scalar!(
+        sub,
+        Sub::sub,
+        u8,
+        i8,
+        u16,
+        i16,
+        f16,
+        u32,
+        i32,
+        f32,
+        u64,
+        i64,
+        f64
+    );
+    impl_binop_scalar!(div, Div::div, f16, f32, f64);
+    impl_binop_scalar!(
+        mul,
+        Mul::mul,
+        u8,
+        i8,
+        u16,
+        i16,
+        f16,
+        u32,
+        i32,
+        f32,
+        u64,
+        i64,
+        f64
+    );
+    impl_binop_scalar!(min, Ord::min, u8, i8, u16, i16, u32, i32, u64, i64);
+    impl_binop_scalar!(min, f16::min, f16);
+    impl_binop_scalar!(min, f32::min, f32);
+    impl_binop_scalar!(min, f64::min, f64);
+    impl_binop_scalar!(max, Ord::max, u8, i8, u16, i16, u32, i32, u64, i64);
+    impl_binop_scalar!(max, f16::max, f16);
+    impl_binop_scalar!(max, f32::max, f32);
+    impl_binop_scalar!(max, f64::max, f64);
+
+    impl_binop_scalar_full!(bitand, BitAnd::bitand);
+    impl_binop_scalar_full!(bitor, BitOr::bitor);
+    impl_binop_scalar_full!(bitxor, BitXor::bitxor);
+
+    impl_unop_scalar!(recip, recip, f16, f32, f64);
+    impl_unop_scalar!(abs, abs, i8, i16, f16, i32, f32, i64, f64);
+
+    impl_cmp_scalar!(equals, eq, u8, i8, u16, i16, u32, i32, f32, u64, i64, f64);
+    impl_cmp_scalar!(
+        greater_than,
+        gt,
+        u8,
+        i8,
+        u16,
+        i16,
+        u32,
+        i32,
+        f32,
+        u64,
+        i64,
+        f64
+    );
+    impl_cmp_scalar!(
+        greater_than_or_equal,
+        ge,
+        u8,
+        i8,
+        u16,
+        i16,
+        u32,
+        i32,
+        f32,
+        u64,
+        i64,
+        f64
+    );
+    impl_cmp_scalar!(
+        less_than, lt, u8, i8, u16, i16, u32, i32, f32, u64, i64, f64
+    );
+    impl_cmp_scalar!(
+        less_than_or_equal,
+        le,
+        u8,
+        i8,
+        u16,
+        i16,
+        u32,
+        i32,
+        f32,
+        u64,
+        i64,
+        f64
+    );
+
+    fn vectorize<Op: WithSimd>(op: Op) -> Op::Output {
+        op.with_simd::<Self>()
+    }
+
+    #[inline(always)]
+    unsafe fn load<T: Scalar>(ptr: *const T) -> super::Vector<Self, T> {
+        Self::typed(unsafe { read(ptr as *const u64) })
+    }
+    #[inline(always)]
+    unsafe fn load_unaligned<T: Scalar>(ptr: *const T) -> super::Vector<Self, T> {
+        Self::typed(unsafe { read_unaligned(ptr as *const u64) })
+    }
+    #[inline(always)]
+    unsafe fn load_low<T: Scalar>(ptr: *const T) -> super::Vector<Self, T> {
+        Self::typed((unsafe { read_unaligned(ptr as *const u32) } as u64) << 32)
+    }
+    #[inline(always)]
+    unsafe fn load_high<T: Scalar>(ptr: *const T) -> super::Vector<Self, T> {
+        Self::typed(unsafe { read_unaligned((ptr as *const u32).add(1)) } as u64)
+    }
+    #[inline(always)]
+    unsafe fn store<T: Scalar>(ptr: *mut T, value: super::Vector<Self, T>) {
+        unsafe { write(ptr as *mut u64, cast!(*value)) };
+    }
+    #[inline(always)]
+    unsafe fn store_unaligned<T: Scalar>(ptr: *mut T, value: super::Vector<Self, T>) {
+        unsafe { write_unaligned(ptr as *mut u64, cast!(*value)) };
+    }
+    #[inline(always)]
+    unsafe fn store_low<T: Scalar>(ptr: *mut T, value: super::Vector<Self, T>) {
+        let value: Self::Register = cast!(value);
+        unsafe { write(ptr as *mut u32, (value >> 32) as u32) };
+    }
+    #[inline(always)]
+    unsafe fn store_high<T: Scalar>(ptr: *mut T, value: super::Vector<Self, T>) {
+        let value: Self::Register = cast!(value);
+        unsafe { write(ptr as *mut u32, value as u32) };
+    }
+    #[inline(always)]
+    fn splat_i8(value: i8) -> Self::Register {
+        cast!([value; 8])
+    }
+    #[inline(always)]
+    fn splat_i16(value: i16) -> Self::Register {
+        cast!([value; 4])
+    }
+    #[inline(always)]
+    fn splat_i32(value: i32) -> Self::Register {
+        cast!([value; 2])
+    }
+    #[inline(always)]
+    fn splat_i64(value: i64) -> Self::Register {
+        cast!(value)
+    }
+    #[inline(always)]
+    fn mul_add_f16(a: Self::Register, b: Self::Register, c: Self::Register) -> Self::Register {
+        let a: [f16; 4] = cast!(a);
+        let b: [f16; 4] = cast!(b);
+        let c: [f16; 4] = cast!(c);
+        let mut out = [f16::default(); 4];
+
+        for i in 0..4 {
+            out[i] = a[i] * b[i] + c[i];
+        }
+        cast!(out)
+    }
+    #[inline(always)]
+    fn mul_add_f16_supported() -> bool {
+        false
+    }
+    #[inline(always)]
+    fn mul_add_f32(a: Self::Register, b: Self::Register, c: Self::Register) -> Self::Register {
+        let a: [f32; 2] = cast!(a);
+        let b: [f32; 2] = cast!(b);
+        let c: [f32; 2] = cast!(c);
+        let mut out = [f32::default(); 2];
+
+        for i in 0..2 {
+            out[i] = a[i].mul_add(b[i], c[i]);
+        }
+        cast!(out)
+    }
+    #[inline(always)]
+    fn mul_add_f32_supported() -> bool {
+        false
+    }
+    #[inline(always)]
+    fn mul_add_f64(a: Self::Register, b: Self::Register, c: Self::Register) -> Self::Register {
+        let a: [f64; 1] = cast!(a);
+        let b: [f64; 1] = cast!(b);
+        let c: [f64; 1] = cast!(c);
+        let mut out = [f64::default(); 1];
+
+        for i in 0..1 {
+            out[i] = a[i].mul_add(b[i], c[i]);
+        }
+        cast!(out)
+    }
+    #[inline(always)]
+    fn mul_add_f64_supported() -> bool {
+        false
+    }
+
+    fn bitnot(a: Self::Register) -> Self::Register {
+        !a
+    }
+
+    fn bitnot_supported() -> bool {
+        false
+    }
+}

--- a/src/backend/wasm32.rs
+++ b/src/backend/wasm32.rs
@@ -1,0 +1,335 @@
+use core::{
+    arch::wasm32::*,
+    ops::{Add, Div, Mul, Sub},
+    ptr::{read, read_unaligned, write, write_unaligned},
+};
+
+use half::f16;
+use num_traits::real::Real;
+use paste::paste;
+
+use crate::{Scalar, WithSimd};
+
+use super::{
+    Simd, VRegister, Vector,
+    arch::{NullaryFnOnce, impl_simd},
+    cast,
+};
+
+impl VRegister for v128 {}
+
+pub struct Simd128;
+
+macro_rules! impl_binop {
+    ($name: ident, $intrinsic: ident, $($ty: ident x $lanes: literal),*) => {
+        $(paste! {
+            fn [<$name _ $ty>](a: Self::Register, b: Self::Register) -> Self::Register {
+                unsafe { [<$ty x $lanes _ $intrinsic>](a, b) }
+            }
+            fn [<$name _ $ty _supported>]() -> bool {
+                true
+            }
+        })*
+    };
+}
+
+macro_rules! impl_unop {
+    ($name: ident, $intrinsic: ident, $($ty: ident x $lanes: literal),*) => {
+        $(paste! {
+            fn [<$name _ $ty>](a: Self::Register) -> Self::Register {
+                unsafe { [<$ty x $lanes _ $intrinsic>](a) }
+            }
+            fn [<$name _ $ty _supported>]() -> bool {
+                true
+            }
+        })*
+    };
+}
+
+macro_rules! impl_cmp {
+    ($name: ident, $intrinsic: ident, $($ty: ident x $lanes: literal),*) => {
+        $(paste! {
+            fn [<$name _ $ty>](a: Self::Register, b: Self::Register) -> <$ty as Scalar>::Mask<Self> {
+                cast!([<$ty x $lanes _ $intrinsic>](a, b))
+            }
+            fn [<$name _ $ty _supported>]() -> bool {
+                true
+            }
+        })*
+    };
+}
+
+macro_rules! impl_binop_scalar {
+    ($func: ident, $intrinsic: path, $($ty: ty),*) => {
+        $(paste! {
+            #[inline(always)]
+            fn [<$func _ $ty>](a: Self::Register, b: Self::Register) -> Self::Register {
+                const LANES: usize = 16 / size_of::<$ty>();
+                let a: [$ty; LANES] = cast!(a);
+                let b: [$ty; LANES] = cast!(b);
+                let mut out = [$ty::default(); LANES];
+
+                for i in 0..LANES {
+                    out[i] = $intrinsic(a[i], b[i]);
+                }
+                cast!(out)
+            }
+            #[inline(always)]
+            fn [<$func _ $ty _supported>]() -> bool {
+                false
+            }
+        })*
+    };
+}
+
+macro_rules! impl_unop_scalar {
+    ($func: ident, $intrinsic: path, $($ty: ty),*) => {
+        $(paste! {
+            #[inline(always)]
+            fn [<$func _ $ty>](a: Self::Register) -> Self::Register {
+                const LANES: usize = 16 / size_of::<$ty>();
+                let a: [$ty; LANES] = cast!(a);
+                let mut out = [$ty::default(); LANES];
+
+                for i in 0..LANES {
+                    out[i] = a[i].$intrinsic();
+                }
+                cast!(out)
+            }
+            #[inline(always)]
+            fn [<$func _ $ty _supported>]() -> bool {
+                false
+            }
+        })*
+    };
+}
+
+macro_rules! lanes {
+    ($($bits: literal),*) => {
+        $(paste! {
+            #[inline(always)]
+            fn [<lanes $bits>]() -> usize {
+                128 / $bits
+            }
+        })*
+    };
+}
+
+impl Simd for Simd128 {
+    type Register = v128;
+    type Mask8 = Vector<Self, i8>;
+    type Mask16 = Vector<Self, i16>;
+    type Mask32 = Vector<Self, i32>;
+    type Mask64 = Vector<Self, i64>;
+
+    lanes!(8, 16, 32, 64);
+
+    impl_binop!(add, add, u8 x 16, i8 x 16, u16 x 8, i16 x 8, u32 x 4, i32 x 4, f32 x 4, u64 x 2, i64 x 2, f64 x 2);
+    impl_binop!(sub, sub, u8 x 16, i8 x 16, u16 x 8, i16 x 8, u32 x 4, i32 x 4, f32 x 4, u64 x 2, i64 x 2, f64 x 2);
+    impl_binop!(mul, mul, u16 x 8, i16 x 8, u32 x 4, i32 x 4, f32 x 4, u64 x 2, i64 x 2, f64 x 2);
+    impl_binop!(div, div, f32 x 4, f64 x 2);
+    impl_binop!(min, min, u8 x 16, i8 x 16, u16 x 8, i16 x 8, u32 x 4, i32 x 4, f32 x 4, f64 x 2);
+    impl_binop!(max, max, u8 x 16, i8 x 16, u16 x 8, i16 x 8, u32 x 4, i32 x 4, f32 x 4, f64 x 2);
+
+    impl_cmp!(equals, eq, u8 x 16, i8 x 16, u16 x 8, i16 x 8, u32 x 4, i32 x 4, f32 x 4, u64 x 2, i64 x 2, f64 x 2);
+    impl_cmp!(less_than, lt, u8 x 16, i8 x 16, u16 x 8, i16 x 8, u32 x 4, i32 x 4, f32 x 4, i64 x 2, f64 x 2);
+    impl_cmp!(less_than_or_equal, le, u8 x 16, i8 x 16, u16 x 8, i16 x 8, u32 x 4, i32 x 4, f32 x 4, i64 x 2, f64 x 2);
+    impl_cmp!(greater_than, gt, u8 x 16, i8 x 16, u16 x 8, i16 x 8, u32 x 4, i32 x 4, f32 x 4, i64 x 2, f64 x 2);
+    impl_cmp!(greater_than_or_equal, ge, u8 x 16, i8 x 16, u16 x 8, i16 x 8, u32 x 4, i32 x 4, f32 x 4, i64 x 2, f64 x 2);
+
+    impl_unop!(abs, abs, i8 x 16, i16 x 8, i32 x 4, f32 x 4, i64 x 2, f64 x 2);
+
+    impl_binop_scalar!(add, Add::add, f16);
+    impl_binop_scalar!(sub, Sub::sub, f16);
+    impl_binop_scalar!(mul, Mul::mul, u8, i8, f16);
+    impl_binop_scalar!(div, Div::div, f16);
+    impl_binop_scalar!(min, Ord::min, u64, i64);
+    impl_binop_scalar!(min, f16::min, f16);
+    impl_binop_scalar!(max, Ord::max, u64, i64);
+    impl_binop_scalar!(max, f16::max, f16);
+
+    impl_unop_scalar!(abs, abs, f16);
+    impl_unop_scalar!(recip, recip, f16, f32, f64);
+
+    fn vectorize<Op: WithSimd>(op: Op) -> Op::Output {
+        struct Impl<Op> {
+            op: Op,
+        }
+        impl<Op: WithSimd> NullaryFnOnce for Impl<Op> {
+            type Output = Op::Output;
+
+            #[inline(always)]
+            fn call(self) -> Self::Output {
+                self.op.with_simd::<Simd128>()
+            }
+        }
+        Self::run_vectorized(Impl { op })
+    }
+
+    #[inline(always)]
+    unsafe fn load<T: Scalar>(ptr: *const T) -> super::Vector<Self, T> {
+        cast!(read(ptr as *const v128))
+    }
+    #[inline(always)]
+    unsafe fn load_unaligned<T: Scalar>(ptr: *const T) -> super::Vector<Self, T> {
+        cast!(read_unaligned(ptr as *const v128))
+    }
+    #[inline(always)]
+    unsafe fn load_low<T: Scalar>(ptr: *const T) -> super::Vector<Self, T> {
+        cast!(v128_load64_zero(ptr as _))
+    }
+    #[inline(always)]
+    unsafe fn load_high<T: Scalar>(ptr: *const T) -> super::Vector<Self, T> {
+        cast!(v128_load64_lane::<1>(
+            Self::splat_u64(0),
+            (ptr as *const u64).add(1)
+        ))
+    }
+    #[inline(always)]
+    unsafe fn store<T: Scalar>(ptr: *mut T, value: super::Vector<Self, T>) {
+        unsafe { write(ptr as *mut v128, cast!(value)) };
+    }
+    #[inline(always)]
+    unsafe fn store_unaligned<T: Scalar>(ptr: *mut T, value: super::Vector<Self, T>) {
+        unsafe { write_unaligned(ptr as *mut v128, cast!(value)) };
+    }
+    #[inline(always)]
+    unsafe fn store_low<T: Scalar>(ptr: *mut T, value: super::Vector<Self, T>) {
+        unsafe { v128_store64_lane::<0>(cast!(value), ptr as _) };
+    }
+    #[inline(always)]
+    unsafe fn store_high<T: Scalar>(ptr: *mut T, value: super::Vector<Self, T>) {
+        unsafe { v128_store64_lane::<1>(cast!(value), ptr as _) };
+    }
+    #[inline(always)]
+    fn splat_i8(value: i8) -> Self::Register {
+        unsafe { i8x16_splat(value) }
+    }
+    #[inline(always)]
+    fn splat_i16(value: i16) -> Self::Register {
+        unsafe { i16x8_splat(value) }
+    }
+    #[inline(always)]
+    fn splat_i32(value: i32) -> Self::Register {
+        unsafe { i32x4_splat(value) }
+    }
+    #[inline(always)]
+    fn splat_i64(value: i64) -> Self::Register {
+        unsafe { i64x2_splat(value) }
+    }
+    #[inline(always)]
+    fn bitand(a: Self::Register, b: Self::Register) -> Self::Register {
+        unsafe { v128_and(a, b) }
+    }
+    #[inline(always)]
+    fn bitand_supported() -> bool {
+        true
+    }
+    #[inline(always)]
+    fn bitor(a: Self::Register, b: Self::Register) -> Self::Register {
+        unsafe { v128_or(a, b) }
+    }
+    #[inline(always)]
+    fn bitor_supported() -> bool {
+        true
+    }
+    #[inline(always)]
+    fn bitxor(a: Self::Register, b: Self::Register) -> Self::Register {
+        unsafe { v128_xor(a, b) }
+    }
+    #[inline(always)]
+    fn bitxor_supported() -> bool {
+        true
+    }
+    #[inline(always)]
+    fn bitnot(a: Self::Register) -> Self::Register {
+        unsafe { v128_not(a) }
+    }
+    #[inline(always)]
+    fn bitnot_supported() -> bool {
+        true
+    }
+    #[inline(always)]
+    fn less_than_u64(a: Self::Register, b: Self::Register) -> <u64 as Scalar>::Mask<Self> {
+        let bias = Self::splat_i64(i64::MIN);
+        let a = Self::sub_u64(a, bias);
+        let b = Self::sub_u64(b, bias);
+        Self::less_than_i64(a, b)
+    }
+    #[inline(always)]
+    fn less_than_u64_supported() -> bool {
+        true
+    }
+    #[inline(always)]
+    fn less_than_or_equal_u64(a: Self::Register, b: Self::Register) -> <u64 as Scalar>::Mask<Self> {
+        let bias = Self::splat_i64(i64::MIN);
+        let a = Self::sub_u64(a, bias);
+        let b = Self::sub_u64(b, bias);
+        Self::less_than_or_equal_i64(a, b)
+    }
+    #[inline(always)]
+    fn less_than_or_equal_u64_supported() -> bool {
+        true
+    }
+    #[inline(always)]
+    fn greater_than_u64(a: Self::Register, b: Self::Register) -> <u64 as Scalar>::Mask<Self> {
+        let bias = Self::splat_i64(i64::MIN);
+        let a = Self::sub_u64(a, bias);
+        let b = Self::sub_u64(b, bias);
+        Self::greater_than_i64(a, b)
+    }
+    #[inline(always)]
+    fn greater_than_u64_supported() -> bool {
+        true
+    }
+    #[inline(always)]
+    fn greater_than_or_equal_u64(
+        a: Self::Register,
+        b: Self::Register,
+    ) -> <u64 as Scalar>::Mask<Self> {
+        let bias = Self::splat_i64(i64::MIN);
+        let a = Self::sub_u64(a, bias);
+        let b = Self::sub_u64(b, bias);
+        Self::greater_than_or_equal_i64(a, b)
+    }
+    #[inline(always)]
+    fn greater_than_or_equal_u64_supported() -> bool {
+        true
+    }
+    #[inline(always)]
+    fn mul_add_f16(a: Self::Register, b: Self::Register, c: Self::Register) -> Self::Register {
+        let a: [f16; 8] = cast!(a);
+        let b: [f16; 8] = cast!(b);
+        let c: [f16; 8] = cast!(c);
+        let mut out = [f16::default(); 8];
+
+        for i in 0..8 {
+            out[i] = a[i].mul_add(b[i], c[i]);
+        }
+        cast!(out)
+    }
+    #[inline(always)]
+    fn mul_add_f16_supported() -> bool {
+        false
+    }
+    #[inline(always)]
+    fn mul_add_f32(a: Self::Register, b: Self::Register, c: Self::Register) -> Self::Register {
+        unsafe { f32x4_relaxed_madd(a, b, c) }
+    }
+    #[inline(always)]
+    fn mul_add_f32_supported() -> bool {
+        true
+    }
+    #[inline(always)]
+    fn mul_add_f64(a: Self::Register, b: Self::Register, c: Self::Register) -> Self::Register {
+        unsafe { f64x2_relaxed_madd(a, b, c) }
+    }
+    #[inline(always)]
+    fn mul_add_f64_supported() -> bool {
+        true
+    }
+}
+
+impl Simd128 {
+    impl_simd!("simd128");
+}

--- a/src/backend/x86/mod.rs
+++ b/src/backend/x86/mod.rs
@@ -1,0 +1,124 @@
+#![allow(
+    clippy::missing_transmute_annotations,
+    clippy::useless_transmute,
+    clippy::transmute_int_to_float,
+    unused_unsafe
+)]
+
+pub mod v2;
+pub mod v3;
+
+macro_rules! with_ty {
+    ($func: ident, f16) => {
+        paste!([<$func _ph>])
+    };
+    ($func: ident, f32) => {
+        paste!([<$func _ps>])
+    };
+    ($func: ident, f64) => {
+        paste!([<$func _pd>])
+    };
+    ($func: ident, $ty: ident) => {
+        paste!([<$func _ep $ty>])
+    }
+}
+pub(crate) use with_ty;
+
+macro_rules! with_ty_signless {
+    ($func: ident, u8) => {
+        with_ty!($func, i8)
+    };
+    ($func: ident, u16) => {
+        with_ty!($func, i16)
+    };
+    ($func: ident, u32) => {
+        with_ty!($func, i32)
+    };
+    ($func: ident, u64) => {
+        with_ty!($func, i64)
+    };
+    ($func: ident, $ty: ident) => {
+        with_ty!($func, $ty)
+    };
+}
+pub(crate) use with_ty_signless;
+
+macro_rules! impl_binop_signless {
+    ($func: ident, $intrinsic: ident, $($ty: ty),*) => {
+        $(paste! {
+            #[inline(always)]
+            fn [<$func _ $ty>](a: Self::Register, b: Self::Register) -> Self::Register {
+                cast!(with_ty_signless!($intrinsic, $ty)(cast!(a), cast!(b)))
+            }
+            #[inline(always)]
+            fn [<$func _ $ty _supported>]() -> bool {
+                true
+            }
+        })*
+    };
+}
+pub(crate) use impl_binop_signless;
+
+macro_rules! impl_binop {
+    ($func: ident, $intrinsic: ident, $($ty: ty),*) => {
+        $(paste! {
+            #[inline(always)]
+            fn [<$func _ $ty>](a: Self::Register, b: Self::Register) -> Self::Register {
+                cast!(with_ty!($intrinsic, $ty)(cast!(a), cast!(b)))
+            }
+            #[inline(always)]
+            fn [<$func _ $ty _supported>]() -> bool {
+                true
+            }
+        })*
+    };
+}
+pub(crate) use impl_binop;
+
+macro_rules! impl_binop_untyped {
+    ($func: ident, $intrinsic: ident) => {
+        paste! {
+            #[inline(always)]
+            fn $func(a: Self::Register, b: Self::Register) -> Self::Register {
+                cast!($intrinsic(cast!(a), cast!(b)))
+            }
+            #[inline(always)]
+            fn [<$func _supported>]() -> bool {
+                true
+            }
+        }
+    };
+}
+pub(crate) use impl_binop_untyped;
+
+macro_rules! impl_unop {
+    ($func: ident, $intrinsic: ident, $($ty: ty),*) => {
+        $(paste! {
+            #[inline(always)]
+            fn [<$func _ $ty>](a: Self::Register) -> Self::Register {
+                cast!(with_ty!($intrinsic, $ty)(cast!(a)))
+            }
+            #[inline(always)]
+            fn [<$func _ $ty _supported>]() -> bool {
+                true
+            }
+        })*
+    };
+}
+pub(crate) use impl_unop;
+
+macro_rules! impl_cmp {
+    ($func: ident, $intrinsic: ident, $($ty: ty),*) => {
+        $(paste! {
+            #[inline(always)]
+            fn [<$func _ $ty>](a: Self::Register, b: Self::Register) -> <$ty as Scalar>::Mask<Self> {
+                cast!(with_ty_signless!($intrinsic, $ty)(cast!(a), cast!(b)))
+            }
+            #[inline(always)]
+            fn [<$func _ $ty _supported>]() -> bool {
+                true
+            }
+        })*
+    };
+}
+pub(crate) use impl_cmp;

--- a/src/backend/x86/v2.rs
+++ b/src/backend/x86/v2.rs
@@ -1,0 +1,400 @@
+use arch::*;
+#[cfg(target_arch = "x86")]
+use core::arch::x86 as arch;
+#[cfg(target_arch = "x86_64")]
+use core::arch::x86_64 as arch;
+use core::ops::{Add, Div, Mul, Sub};
+
+use half::f16;
+use num_traits::Float;
+use paste::paste;
+
+use crate::{Scalar, WithSimd, backend::arch::NullaryFnOnce};
+
+use crate::backend::{Simd, VRegister, Vector, arch::impl_simd, cast};
+
+use super::*;
+
+impl VRegister for __m128 {}
+
+pub struct V2;
+
+macro_rules! impl_binop_scalar {
+    ($func: ident, $intrinsic: path, $($ty: ty),*) => {
+        $(paste! {
+            #[inline(always)]
+            fn [<$func _ $ty>](a: Self::Register, b: Self::Register) -> Self::Register {
+                const LANES: usize = 16 / size_of::<$ty>();
+                let a: [$ty; LANES] = cast!(a);
+                let b: [$ty; LANES] = cast!(b);
+                let mut out = [$ty::default(); LANES];
+
+                for i in 0..LANES {
+                    out[i] = $intrinsic(a[i], b[i]);
+                }
+                cast!(out)
+            }
+            #[inline(always)]
+            fn [<$func _ $ty _supported>]() -> bool {
+                false
+            }
+        })*
+    };
+}
+
+macro_rules! impl_unop_scalar {
+    ($func: ident, $intrinsic: path, $($ty: ty),*) => {
+        $(paste! {
+            #[inline(always)]
+            fn [<$func _ $ty>](a: Self::Register) -> Self::Register {
+                const LANES: usize = 16 / size_of::<$ty>();
+                let a: [$ty; LANES] = cast!(a);
+                let mut out = [$ty::default(); LANES];
+
+                for i in 0..LANES {
+                    out[i] = a[i].$intrinsic();
+                }
+                cast!(out)
+            }
+            #[inline(always)]
+            fn [<$func _ $ty _supported>]() -> bool {
+                false
+            }
+        })*
+    };
+}
+
+macro_rules! cmp_int {
+    ($($ty: ty),*) => {
+        $(paste! {
+            #[inline(always)]
+            fn [<less_than_or_equal_ $ty>](
+                a: Self::Register,
+                b: Self::Register,
+            ) -> <$ty as Scalar>::Mask<Self> {
+                let gt = Self::[<greater_than_ $ty>](a, b);
+                cast!(Self::bitnot(cast!(gt)))
+            }
+            #[inline(always)]
+            fn [<less_than_or_equal_ $ty _supported>]() -> bool {
+                Self::[<greater_than_ $ty _supported>]()
+            }
+            #[inline(always)]
+            fn [<greater_than_or_equal_ $ty>](
+                a: Self::Register,
+                b: Self::Register,
+            ) -> <$ty as Scalar>::Mask<Self> {
+                let gt = Self::[<less_than_ $ty>](a, b);
+                cast!(Self::bitnot(cast!(gt)))
+            }
+            #[inline(always)]
+            fn [<greater_than_or_equal_ $ty _supported>]() -> bool {
+                Self::[<less_than_ $ty _supported>]()
+            }
+        })*
+    };
+}
+
+macro_rules! lanes {
+    ($($bits: literal),*) => {
+        $(paste! {
+            #[inline(always)]
+            fn [<lanes $bits>]() -> usize {
+                128 / $bits
+            }
+        })*
+    };
+}
+
+impl Simd for V2 {
+    type Register = __m128;
+    type Mask8 = Vector<Self, i8>;
+    type Mask16 = Vector<Self, i16>;
+    type Mask32 = Vector<Self, i32>;
+    type Mask64 = Vector<Self, i64>;
+
+    lanes!(8, 16, 32, 64);
+
+    impl_binop_signless!(add, _mm_add, u8, i8, u16, i16, u32, i32, f32, u64, i64, f64);
+    impl_binop_signless!(sub, _mm_sub, u8, i8, u16, i16, u32, i32, f32, u64, i64, f64);
+    impl_binop!(div, _mm_div, f32, f64);
+    impl_binop_signless!(mul, _mm_mul, f32, f64);
+    impl_binop_signless!(mul, _mm_mullo, u16, i16, u32, i32);
+    impl_binop!(min, _mm_min, u8, i8, u16, i16, u32, i32, f32, f64);
+    impl_binop!(max, _mm_max, u8, i8, u16, i16, u32, i32, f32, f64);
+    impl_binop_scalar!(add, Add::add, f16);
+    impl_binop_scalar!(sub, Sub::sub, f16);
+    impl_binop_scalar!(div, Div::div, f16);
+    impl_binop_scalar!(mul, Mul::mul, i8, u8, f16, u64, i64);
+    impl_binop_scalar!(min, Ord::min, u64, i64);
+    impl_binop_scalar!(min, f16::min, f16);
+    impl_binop_scalar!(max, Ord::max, u64, i64);
+    impl_binop_scalar!(max, f16::max, f16);
+
+    impl_binop_untyped!(bitand, _mm_and_si128);
+    impl_binop_untyped!(bitor, _mm_or_si128);
+    impl_binop_untyped!(bitxor, _mm_xor_si128);
+
+    impl_unop!(recip, _mm_rcp, f32);
+    impl_unop!(abs, _mm_abs, i8, i16, i32);
+    impl_unop_scalar!(recip, recip, f16, f64);
+
+    impl_cmp!(
+        equals, _mm_cmpeq, u8, i8, u16, i16, u32, i32, f32, u64, i64, f64
+    );
+    impl_cmp!(greater_than, _mm_cmpgt, i8, i16, i32, f32, i64, f64);
+    impl_cmp!(greater_than_or_equal, _mm_cmpge, f32, f64);
+    impl_cmp!(less_than, _mm_cmplt, i8, i16, i32, f32, f64);
+    impl_cmp!(less_than_or_equal, _mm_cmple, f32, f64);
+
+    cmp_int!(u8, i8, u16, i16, u32, i32, u64, i64);
+
+    fn vectorize<Op: WithSimd>(op: Op) -> Op::Output {
+        struct Impl<Op> {
+            op: Op,
+        }
+        impl<Op: WithSimd> NullaryFnOnce for Impl<Op> {
+            type Output = Op::Output;
+
+            #[inline(always)]
+            fn call(self) -> Self::Output {
+                self.op.with_simd::<V2>()
+            }
+        }
+        Self::run_vectorized(Impl { op })
+    }
+
+    #[inline(always)]
+    unsafe fn load<T: Scalar>(ptr: *const T) -> Vector<Self, T> {
+        cast!(_mm_load_si128(ptr as _))
+    }
+    #[inline(always)]
+    unsafe fn load_unaligned<T: Scalar>(ptr: *const T) -> Vector<Self, T> {
+        cast!(_mm_lddqu_si128(ptr as _))
+    }
+    #[inline(always)]
+    unsafe fn load_low<T: Scalar>(ptr: *const T) -> Vector<Self, T> {
+        cast!(_mm_loadl_epi64(ptr as _))
+    }
+    #[inline(always)]
+    unsafe fn load_high<T: Scalar>(ptr: *const T) -> Vector<Self, T> {
+        cast!(_mm_loadh_pd(cast!(Self::splat_f64(0.0)), ptr as _))
+    }
+    #[inline(always)]
+    unsafe fn store<T: Scalar>(ptr: *mut T, value: Vector<Self, T>) {
+        unsafe { _mm_store_si128(ptr as _, cast!(value)) };
+    }
+    #[inline(always)]
+    unsafe fn store_unaligned<T: Scalar>(ptr: *mut T, value: Vector<Self, T>) {
+        unsafe { _mm_storeu_si128(ptr as _, cast!(value)) };
+    }
+    #[inline(always)]
+    unsafe fn store_low<T: Scalar>(ptr: *mut T, value: Vector<Self, T>) {
+        unsafe {
+            _mm_storel_epi64(ptr as _, cast!(value));
+        };
+    }
+    #[inline(always)]
+    unsafe fn store_high<T: Scalar>(ptr: *mut T, value: Vector<Self, T>) {
+        unsafe { _mm_storeh_pd(ptr as _, cast!(value)) };
+    }
+
+    #[inline(always)]
+    fn splat_i8(value: i8) -> Self::Register {
+        cast!(_mm_set1_epi8(value))
+    }
+
+    #[inline(always)]
+    fn splat_i16(value: i16) -> Self::Register {
+        cast!(_mm_set1_epi16(value))
+    }
+
+    #[inline(always)]
+    fn splat_i32(value: i32) -> Self::Register {
+        cast!(_mm_set1_epi32(value))
+    }
+
+    #[inline(always)]
+    fn splat_i64(value: i64) -> Self::Register {
+        cast!(_mm_set1_pd(cast!(value)))
+    }
+
+    #[inline(always)]
+    fn less_than_u8(a: Self::Register, b: Self::Register) -> <u8 as Scalar>::Mask<Self> {
+        let bias = Self::splat_i8(i8::MIN);
+        let a = Self::sub_u8(a, bias);
+        let b = Self::sub_u8(b, bias);
+        Self::less_than_i8(a, b)
+    }
+    #[inline(always)]
+    fn less_than_u8_supported() -> bool {
+        true
+    }
+    #[inline(always)]
+    fn less_than_u16(a: Self::Register, b: Self::Register) -> <u16 as Scalar>::Mask<Self> {
+        let bias = Self::splat_i16(i16::MIN);
+        let a = Self::sub_u16(a, bias);
+        let b = Self::sub_u16(b, bias);
+        Self::less_than_i16(a, b)
+    }
+    #[inline(always)]
+    fn less_than_u16_supported() -> bool {
+        true
+    }
+    #[inline(always)]
+    fn less_than_u32(a: Self::Register, b: Self::Register) -> <u32 as Scalar>::Mask<Self> {
+        let bias = Self::splat_i32(i32::MIN);
+        let a = Self::sub_u32(a, bias);
+        let b = Self::sub_u32(b, bias);
+        Self::less_than_i32(a, b)
+    }
+    #[inline(always)]
+    fn less_than_u32_supported() -> bool {
+        true
+    }
+    #[inline(always)]
+    fn less_than_u64(a: Self::Register, b: Self::Register) -> <u64 as Scalar>::Mask<Self> {
+        let bias = Self::splat_i64(i64::MIN);
+        let a = Self::sub_u64(a, bias);
+        let b = Self::sub_u64(b, bias);
+        Self::less_than_i64(a, b)
+    }
+    #[inline(always)]
+    fn less_than_u64_supported() -> bool {
+        true
+    }
+    #[inline(always)]
+    fn greater_than_u8(a: Self::Register, b: Self::Register) -> <u8 as Scalar>::Mask<Self> {
+        let bias = Self::splat_i8(i8::MIN);
+        let a = Self::sub_u8(a, bias);
+        let b = Self::sub_u8(b, bias);
+        Self::greater_than_i8(a, b)
+    }
+    #[inline(always)]
+    fn greater_than_u8_supported() -> bool {
+        true
+    }
+    #[inline(always)]
+    fn greater_than_u16(a: Self::Register, b: Self::Register) -> <u16 as Scalar>::Mask<Self> {
+        let bias = Self::splat_i16(i16::MIN);
+        let a = Self::sub_u16(a, bias);
+        let b = Self::sub_u16(b, bias);
+        Self::greater_than_i16(a, b)
+    }
+    #[inline(always)]
+    fn greater_than_u16_supported() -> bool {
+        true
+    }
+    #[inline(always)]
+    fn greater_than_u32(a: Self::Register, b: Self::Register) -> <u32 as Scalar>::Mask<Self> {
+        let bias = Self::splat_i32(i32::MIN);
+        let a = Self::sub_u32(a, bias);
+        let b = Self::sub_u32(b, bias);
+        Self::greater_than_i32(a, b)
+    }
+    #[inline(always)]
+    fn greater_than_u32_supported() -> bool {
+        true
+    }
+    #[inline(always)]
+    fn greater_than_u64(a: Self::Register, b: Self::Register) -> <u64 as Scalar>::Mask<Self> {
+        let bias = Self::splat_i64(i64::MIN);
+        let a = Self::sub_u64(a, bias);
+        let b = Self::sub_u64(b, bias);
+        Self::greater_than_i64(a, b)
+    }
+    #[inline(always)]
+    fn greater_than_u64_supported() -> bool {
+        true
+    }
+    #[inline(always)]
+    fn less_than_i64(a: Self::Register, b: Self::Register) -> <i64 as Scalar>::Mask<Self> {
+        Self::greater_than_i64(b, a)
+    }
+    #[inline(always)]
+    fn less_than_i64_supported() -> bool {
+        true
+    }
+    #[inline(always)]
+    fn mul_add_f16(a: Self::Register, b: Self::Register, c: Self::Register) -> Self::Register {
+        let a: [f16; 8] = cast!(a);
+        let b: [f16; 8] = cast!(b);
+        let c: [f16; 8] = cast!(c);
+        let mut out = [f16::default(); 8];
+
+        for i in 0..8 {
+            out[i] = a[i] * b[i] + c[i];
+        }
+        cast!(out)
+    }
+    #[inline(always)]
+    fn mul_add_f16_supported() -> bool {
+        false
+    }
+    #[inline(always)]
+    fn mul_add_f32(a: Self::Register, b: Self::Register, c: Self::Register) -> Self::Register {
+        unsafe { _mm_fmadd_ps(a, b, c) }
+    }
+    #[inline(always)]
+    fn mul_add_f32_supported() -> bool {
+        true
+    }
+    #[inline(always)]
+    fn mul_add_f64(a: Self::Register, b: Self::Register, c: Self::Register) -> Self::Register {
+        cast!(_mm_fmadd_pd(cast!(a), cast!(b), cast!(c)))
+    }
+    #[inline(always)]
+    fn mul_add_f64_supported() -> bool {
+        true
+    }
+    #[inline(always)]
+    fn bitnot(a: Self::Register) -> Self::Register {
+        cast!(_mm_xor_si128(cast!(a), cast!(Self::splat_i64(-1))))
+    }
+    #[inline(always)]
+    fn bitnot_supported() -> bool {
+        true
+    }
+    #[inline(always)]
+    fn abs_f16(a: Self::Register) -> Self::Register {
+        let mask = Self::splat_i16(i16::MAX);
+        Self::bitand(a, mask)
+    }
+    #[inline(always)]
+    fn abs_f16_supported() -> bool {
+        true
+    }
+    #[inline(always)]
+    fn abs_f32(a: Self::Register) -> Self::Register {
+        let mask = Self::splat_i32(i32::MAX);
+        Self::bitand(a, mask)
+    }
+    #[inline(always)]
+    fn abs_f32_supported() -> bool {
+        true
+    }
+    #[inline(always)]
+    fn abs_f64(a: Self::Register) -> Self::Register {
+        let mask = Self::splat_i64(i64::MAX);
+        Self::bitand(a, mask)
+    }
+    #[inline(always)]
+    fn abs_f64_supported() -> bool {
+        true
+    }
+    #[inline(always)]
+    fn abs_i64(a: Self::Register) -> Self::Register {
+        let mask = Self::splat_i64(i64::MAX);
+        Self::bitand(a, mask)
+    }
+    #[inline(always)]
+    fn abs_i64_supported() -> bool {
+        true
+    }
+}
+
+impl V2 {
+    impl_simd!(
+        "sse", "sse2", "fxsr", "sse3", "ssse3", "sse4.1", "sse4.2", "popcnt"
+    );
+}

--- a/src/backend/x86/v3.rs
+++ b/src/backend/x86/v3.rs
@@ -1,0 +1,447 @@
+use arch::*;
+use bytemuck::Zeroable;
+#[cfg(target_arch = "x86")]
+use core::arch::x86 as arch;
+#[cfg(target_arch = "x86_64")]
+use core::arch::x86_64 as arch;
+use core::ops::{Add, Div, Mul, Sub};
+
+use half::f16;
+use num_traits::Float;
+use paste::paste;
+
+use crate::{Scalar, WithSimd, backend::arch::NullaryFnOnce};
+
+use crate::backend::{Simd, VRegister, Vector, arch::impl_simd, cast};
+
+use super::*;
+
+impl VRegister for __m256 {}
+
+macro_rules! lanes {
+    ($($bits: literal),*) => {
+        $(paste! {
+            #[inline(always)]
+            fn [<lanes $bits>]() -> usize {
+                256 / $bits
+            }
+        })*
+    };
+}
+
+pub struct V3;
+
+macro_rules! impl_binop_scalar {
+    ($func: ident, $intrinsic: path, $($ty: ty),*) => {
+        $(paste! {
+            #[inline(always)]
+            fn [<$func _ $ty>](a: Self::Register, b: Self::Register) -> Self::Register {
+                const LANES: usize = 32 / size_of::<$ty>();
+                let a: [$ty; LANES] = cast!(a);
+                let b: [$ty; LANES] = cast!(b);
+                let mut out = [$ty::default(); LANES];
+
+                for i in 0..LANES {
+                    out[i] = $intrinsic(a[i], b[i]);
+                }
+                cast!(out)
+            }
+            #[inline(always)]
+            fn [<$func _ $ty _supported>]() -> bool {
+                false
+            }
+        })*
+    };
+}
+
+macro_rules! impl_unop_scalar {
+    ($func: ident, $intrinsic: path, $($ty: ty),*) => {
+        $(paste! {
+            #[inline(always)]
+            fn [<$func _ $ty>](a: Self::Register) -> Self::Register {
+                const LANES: usize = 32 / size_of::<$ty>();
+                let a: [$ty; LANES] = cast!(a);
+                let mut out = [$ty::default(); LANES];
+
+                for i in 0..LANES {
+                    out[i] = a[i].$intrinsic();
+                }
+                cast!(out)
+            }
+            #[inline(always)]
+            fn [<$func _ $ty _supported>]() -> bool {
+                false
+            }
+        })*
+    };
+}
+
+macro_rules! cmp_int {
+    ($($ty: ty),*) => {
+        $(paste! {
+            #[inline(always)]
+            fn [<less_than_ $ty>](
+                a: Self::Register,
+                b: Self::Register,
+            ) -> <$ty as Scalar>::Mask<Self> {
+                Self::[<greater_than_ $ty>](a, b)
+            }
+            #[inline(always)]
+            fn [<less_than_ $ty _supported>]() -> bool {
+                Self::[<greater_than_ $ty _supported>]()
+            }
+            #[inline(always)]
+            fn [<less_than_or_equal_ $ty>](
+                a: Self::Register,
+                b: Self::Register,
+            ) -> <$ty as Scalar>::Mask<Self> {
+                let gt = Self::[<greater_than_ $ty>](a, b);
+                cast!(Self::bitnot(cast!(gt)))
+            }
+            #[inline(always)]
+            fn [<less_than_or_equal_ $ty _supported>]() -> bool {
+                Self::[<greater_than_ $ty _supported>]()
+            }
+            #[inline(always)]
+            fn [<greater_than_or_equal_ $ty>](
+                a: Self::Register,
+                b: Self::Register,
+            ) -> <$ty as Scalar>::Mask<Self> {
+                let gt = Self::[<less_than_ $ty>](a, b);
+                cast!(Self::bitnot(cast!(gt)))
+            }
+            #[inline(always)]
+            fn [<greater_than_or_equal_ $ty _supported>]() -> bool {
+                Self::[<less_than_ $ty _supported>]()
+            }
+        })*
+    };
+}
+
+impl Simd for V3 {
+    type Register = __m256;
+    type Mask8 = Vector<Self, i8>;
+    type Mask16 = Vector<Self, i16>;
+    type Mask32 = Vector<Self, i32>;
+    type Mask64 = Vector<Self, i64>;
+
+    lanes!(8, 16, 32, 64);
+
+    impl_binop_signless!(
+        add, _mm256_add, u8, i8, u16, i16, u32, i32, f32, u64, i64, f64
+    );
+    impl_binop_signless!(
+        sub, _mm256_sub, u8, i8, u16, i16, u32, i32, f32, u64, i64, f64
+    );
+    impl_binop!(div, _mm256_div, f32, f64);
+    impl_binop!(mul, _mm256_mul, f32, f64);
+    impl_binop_signless!(mul, _mm256_mullo, u16, i16, u32, i32);
+    impl_binop!(min, _mm256_min, u8, i8, u16, i16, u32, i32, f32, f64);
+    impl_binop!(max, _mm256_max, u8, i8, u16, i16, u32, i32, f32, f64);
+    impl_binop_scalar!(add, Add::add, f16);
+    impl_binop_scalar!(sub, Sub::sub, f16);
+    impl_binop_scalar!(div, Div::div, f16);
+    impl_binop_scalar!(mul, Mul::mul, i8, u8, f16, u64, i64);
+    impl_binop_scalar!(min, Ord::min, u64, i64);
+    impl_binop_scalar!(min, f16::min, f16);
+    impl_binop_scalar!(max, Ord::max, u64, i64);
+    impl_binop_scalar!(max, f16::max, f16);
+
+    impl_binop_untyped!(bitand, _mm256_and_si256);
+    impl_binop_untyped!(bitor, _mm256_or_si256);
+    impl_binop_untyped!(bitxor, _mm256_xor_si256);
+
+    impl_unop!(recip, _mm256_rcp, f32);
+    impl_unop!(abs, _mm256_abs, i8, i16, i32);
+    impl_unop_scalar!(recip, recip, f16, f64);
+
+    impl_cmp!(equals, _mm256_cmpeq, u8, i8, u16, i16, u32, i32, u64, i64);
+    impl_cmp!(greater_than, _mm256_cmpgt, i8, i16, i32, i64);
+    cmp_int!(u8, i8, u16, i16, u32, i32, u64, i64);
+
+    fn vectorize<Op: WithSimd>(op: Op) -> Op::Output {
+        struct Impl<Op> {
+            op: Op,
+        }
+        impl<Op: WithSimd> NullaryFnOnce for Impl<Op> {
+            type Output = Op::Output;
+
+            #[inline(always)]
+            fn call(self) -> Self::Output {
+                self.op.with_simd::<V3>()
+            }
+        }
+        Self::run_vectorized(Impl { op })
+    }
+
+    #[inline(always)]
+    unsafe fn load<T: Scalar>(ptr: *const T) -> Vector<Self, T> {
+        cast!(_mm256_load_si256(ptr as _))
+    }
+    #[inline(always)]
+    unsafe fn load_unaligned<T: Scalar>(ptr: *const T) -> Vector<Self, T> {
+        cast!(_mm256_lddqu_si256(ptr as _))
+    }
+    #[inline(always)]
+    unsafe fn load_low<T: Scalar>(ptr: *const T) -> Vector<Self, T> {
+        let low = unsafe { _mm_lddqu_si128(ptr as _) };
+        cast!(_mm256_castsi128_si256(low))
+    }
+    #[inline(always)]
+    unsafe fn load_high<T: Scalar>(ptr: *const T) -> Vector<Self, T> {
+        let high = unsafe { _mm_lddqu_si128((ptr as *const __m128i).add(1)) };
+        cast!(_mm256_inserti128_si256::<1>(Zeroable::zeroed(), high))
+    }
+    #[inline(always)]
+    unsafe fn store<T: Scalar>(ptr: *mut T, value: Vector<Self, T>) {
+        unsafe { _mm256_store_si256(ptr as _, cast!(*value)) };
+    }
+    #[inline(always)]
+    unsafe fn store_unaligned<T: Scalar>(ptr: *mut T, value: Vector<Self, T>) {
+        unsafe { _mm256_storeu_si256(ptr as _, cast!(*value)) };
+    }
+    #[inline(always)]
+    unsafe fn store_low<T: Scalar>(ptr: *mut T, value: Vector<Self, T>) {
+        let low = unsafe { _mm256_castsi256_si128(cast!(*value)) };
+        unsafe { _mm_storeu_si128(ptr as _, low) };
+    }
+    #[inline(always)]
+    unsafe fn store_high<T: Scalar>(ptr: *mut T, value: Vector<Self, T>) {
+        let high = unsafe { _mm256_extracti128_si256::<1>(cast!(value)) };
+        unsafe { _mm_storeu_si128((ptr as *mut __m128i).add(1), high) };
+    }
+
+    #[inline(always)]
+    fn greater_than_u8(a: Self::Register, b: Self::Register) -> <u8 as Scalar>::Mask<Self> {
+        let bias = Self::splat_i8(i8::MIN);
+        let a = Self::sub_u8(a, bias);
+        let b = Self::sub_u8(b, bias);
+        Self::greater_than_i8(a, b)
+    }
+    #[inline(always)]
+    fn greater_than_u8_supported() -> bool {
+        true
+    }
+    #[inline(always)]
+    fn greater_than_u16(a: Self::Register, b: Self::Register) -> <u16 as Scalar>::Mask<Self> {
+        let bias = Self::splat_i16(i16::MIN);
+        let a = Self::sub_u16(a, bias);
+        let b = Self::sub_u16(b, bias);
+        Self::greater_than_i16(a, b)
+    }
+    #[inline(always)]
+    fn greater_than_u16_supported() -> bool {
+        true
+    }
+    #[inline(always)]
+    fn greater_than_u32(a: Self::Register, b: Self::Register) -> <u32 as Scalar>::Mask<Self> {
+        let bias = Self::splat_i32(i32::MIN);
+        let a = Self::sub_u32(a, bias);
+        let b = Self::sub_u32(b, bias);
+        Self::greater_than_i32(a, b)
+    }
+    #[inline(always)]
+    fn greater_than_u32_supported() -> bool {
+        true
+    }
+    #[inline(always)]
+    fn greater_than_u64(a: Self::Register, b: Self::Register) -> <u64 as Scalar>::Mask<Self> {
+        let bias = Self::splat_i64(i64::MIN);
+        let a = Self::sub_u64(a, bias);
+        let b = Self::sub_u64(b, bias);
+        Self::greater_than_i64(a, b)
+    }
+    #[inline(always)]
+    fn greater_than_u64_supported() -> bool {
+        true
+    }
+
+    #[inline(always)]
+    fn splat_i8(value: i8) -> Self::Register {
+        cast!(_mm256_set1_epi8(value))
+    }
+
+    #[inline(always)]
+    fn splat_i16(value: i16) -> Self::Register {
+        cast!(_mm256_set1_epi16(value))
+    }
+
+    #[inline(always)]
+    fn splat_i32(value: i32) -> Self::Register {
+        cast!(_mm256_set1_epi32(value))
+    }
+
+    #[inline(always)]
+    fn splat_i64(value: i64) -> Self::Register {
+        cast!(_mm256_set1_pd(cast!(value)))
+    }
+    #[inline(always)]
+    fn equals_f32(a: Self::Register, b: Self::Register) -> <f32 as Scalar>::Mask<Self> {
+        cast!(_mm256_cmp_ps::<_CMP_EQ_UQ>(cast!(a), cast!(b)))
+    }
+    #[inline(always)]
+    fn equals_f32_supported() -> bool {
+        true
+    }
+    #[inline(always)]
+    fn equals_f64(a: Self::Register, b: Self::Register) -> <f64 as Scalar>::Mask<Self> {
+        cast!(_mm256_cmp_pd::<_CMP_EQ_UQ>(cast!(a), cast!(b)))
+    }
+    #[inline(always)]
+    fn equals_f64_supported() -> bool {
+        true
+    }
+    #[inline(always)]
+    fn less_than_f32(a: Self::Register, b: Self::Register) -> <f32 as Scalar>::Mask<Self> {
+        cast!(_mm256_cmp_ps::<_CMP_LT_OQ>(cast!(a), cast!(b)))
+    }
+    #[inline(always)]
+    fn less_than_f32_supported() -> bool {
+        true
+    }
+    #[inline(always)]
+    fn less_than_f64(a: Self::Register, b: Self::Register) -> <f64 as Scalar>::Mask<Self> {
+        cast!(_mm256_cmp_pd::<_CMP_LT_OQ>(cast!(a), cast!(b)))
+    }
+    #[inline(always)]
+    fn less_than_f64_supported() -> bool {
+        true
+    }
+    #[inline(always)]
+    fn less_than_or_equal_f32(a: Self::Register, b: Self::Register) -> <f32 as Scalar>::Mask<Self> {
+        cast!(_mm256_cmp_ps::<_CMP_LE_OQ>(cast!(a), cast!(b)))
+    }
+    #[inline(always)]
+    fn less_than_or_equal_f32_supported() -> bool {
+        true
+    }
+    #[inline(always)]
+    fn less_than_or_equal_f64(a: Self::Register, b: Self::Register) -> <f64 as Scalar>::Mask<Self> {
+        cast!(_mm256_cmp_pd::<_CMP_LE_OQ>(cast!(a), cast!(b)))
+    }
+    #[inline(always)]
+    fn less_than_or_equal_f64_supported() -> bool {
+        true
+    }
+    #[inline(always)]
+    fn greater_than_f32(a: Self::Register, b: Self::Register) -> <f32 as Scalar>::Mask<Self> {
+        cast!(_mm256_cmp_ps::<_CMP_GT_OQ>(cast!(a), cast!(b)))
+    }
+    #[inline(always)]
+    fn greater_than_f32_supported() -> bool {
+        true
+    }
+    #[inline(always)]
+    fn greater_than_f64(a: Self::Register, b: Self::Register) -> <f64 as Scalar>::Mask<Self> {
+        cast!(_mm256_cmp_pd::<_CMP_GT_OQ>(cast!(a), cast!(b)))
+    }
+    #[inline(always)]
+    fn greater_than_f64_supported() -> bool {
+        true
+    }
+    #[inline(always)]
+    fn greater_than_or_equal_f32(
+        a: Self::Register,
+        b: Self::Register,
+    ) -> <f32 as Scalar>::Mask<Self> {
+        cast!(_mm256_cmp_ps::<_CMP_GE_OQ>(cast!(a), cast!(b)))
+    }
+    #[inline(always)]
+    fn greater_than_or_equal_f32_supported() -> bool {
+        true
+    }
+    #[inline(always)]
+    fn greater_than_or_equal_f64(
+        a: Self::Register,
+        b: Self::Register,
+    ) -> <f64 as Scalar>::Mask<Self> {
+        cast!(_mm256_cmp_pd::<_CMP_GE_OQ>(cast!(a), cast!(b)))
+    }
+    #[inline(always)]
+    fn greater_than_or_equal_f64_supported() -> bool {
+        true
+    }
+    #[inline(always)]
+    fn mul_add_f16(a: Self::Register, b: Self::Register, c: Self::Register) -> Self::Register {
+        let a: [f16; 16] = cast!(a);
+        let b: [f16; 16] = cast!(b);
+        let c: [f16; 16] = cast!(c);
+        let mut out = [f16::default(); 16];
+
+        for i in 0..16 {
+            out[i] = a[i] * b[i] + c[i];
+        }
+        cast!(out)
+    }
+    #[inline(always)]
+    fn mul_add_f16_supported() -> bool {
+        false
+    }
+    #[inline(always)]
+    fn mul_add_f32(a: Self::Register, b: Self::Register, c: Self::Register) -> Self::Register {
+        unsafe { _mm256_fmadd_ps(a, b, c) }
+    }
+    #[inline(always)]
+    fn mul_add_f32_supported() -> bool {
+        true
+    }
+    #[inline(always)]
+    fn mul_add_f64(a: Self::Register, b: Self::Register, c: Self::Register) -> Self::Register {
+        cast!(_mm256_fmadd_pd(cast!(a), cast!(b), cast!(c)))
+    }
+    #[inline(always)]
+    fn mul_add_f64_supported() -> bool {
+        true
+    }
+    #[inline(always)]
+    fn bitnot(a: Self::Register) -> Self::Register {
+        cast!(_mm256_xor_si256(cast!(a), cast!(Self::splat_i64(-1))))
+    }
+    #[inline(always)]
+    fn bitnot_supported() -> bool {
+        true
+    }
+    #[inline(always)]
+    fn abs_f16(a: Self::Register) -> Self::Register {
+        let mask = Self::splat_i16(i16::MAX);
+        Self::bitand(a, mask)
+    }
+    #[inline(always)]
+    fn abs_f16_supported() -> bool {
+        true
+    }
+    #[inline(always)]
+    fn abs_f32(a: Self::Register) -> Self::Register {
+        let mask = Self::splat_i32(i32::MAX);
+        Self::bitand(a, mask)
+    }
+    #[inline(always)]
+    fn abs_f32_supported() -> bool {
+        true
+    }
+    #[inline(always)]
+    fn abs_f64(a: Self::Register) -> Self::Register {
+        let mask = Self::splat_i64(i64::MAX);
+        Self::bitand(a, mask)
+    }
+    #[inline(always)]
+    fn abs_f64_supported() -> bool {
+        true
+    }
+    #[inline(always)]
+    fn abs_i64(a: Self::Register) -> Self::Register {
+        let mask = Self::splat_i64(i64::MAX);
+        Self::bitand(a, mask)
+    }
+    #[inline(always)]
+    fn abs_i64_supported() -> bool {
+        true
+    }
+}
+
+impl V3 {
+    impl_simd!(
+        "sse", "sse2", "fxsr", "sse3", "ssse3", "sse4.1", "sse4.2", "popcnt", "avx", "avx2",
+        "bmi1", "bmi2", "fma", "lzcnt"
+    );
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,17 @@
-#![cfg_attr(feature = "std", no_std)]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 mod arithmetic;
+pub(crate) mod backend;
 mod base;
 mod bitwise;
 mod ord;
 mod unary;
 
 pub use arithmetic::*;
+pub use backend::*;
 pub use base::*;
 pub use bitwise::*;
 pub use ord::*;
 pub use unary::*;
+
+pub use macerator_macros::*;

--- a/src/ord.rs
+++ b/src/ord.rs
@@ -1,26 +1,34 @@
 use paste::paste;
-use pulp::Simd;
 
-use crate::Vectorizable;
+use crate::{Scalar, Simd, Vector};
 
-pub trait VEq: Vectorizable + PartialEq {
+pub trait VEq: Scalar + PartialEq {
     /// Compare two vectors for elementwise equality
-    fn veq<S: Simd>(simd: S, a: Self::Vector<S>, b: Self::Vector<S>) -> Self::Mask<S>;
+    fn veq<S: Simd>(a: Vector<S, Self>, b: Vector<S, Self>) -> Self::Mask<S>;
+    fn is_accelerated<S: Simd>() -> bool;
 }
 
 macro_rules! impl_veq {
-    ($ty: ty) => {
-        paste! {
+    ($($ty: ty),*) => {
+        $(paste! {
             impl VEq for $ty {
                 #[inline(always)]
-                fn veq<S: Simd>(simd: S, a: Self::Vector<S>, b: Self::Vector<S>) -> Self::Mask<S> {
-                    simd.[<equal_ $ty s>](a, b)
+                fn veq<S: Simd>(a: Vector<S, Self>, b: Vector<S, Self>) -> Self::Mask<S> {
+                    S::[<equals_ $ty>](*a, *b)
+                }
+                #[inline(always)]
+                fn is_accelerated<S: Simd>() -> bool {
+                    S::[<equals_ $ty _supported>]()
                 }
             }
-        }
+        })*
     };
-    ($($ty: ty),*) => {
-        $(impl_veq!($ty);)*
+}
+
+impl<S: Simd, T: VEq> Vector<S, T> {
+    #[inline(always)]
+    pub fn eq(self, other: Self) -> T::Mask<S> {
+        T::veq(self, other)
     }
 }
 
@@ -28,53 +36,93 @@ impl_veq!(u8, i8, u16, i16, u32, i32, f32, u64, i64, f64);
 
 pub trait VOrd: VEq {
     /// Apply elementwise [`PartialOrd::lt`] on two vectors
-    fn vlt<S: Simd>(simd: S, a: Self::Vector<S>, b: Self::Vector<S>) -> Self::Mask<S>;
+    fn vlt<S: Simd>(a: Vector<S, Self>, b: Vector<S, Self>) -> Self::Mask<S>;
     /// Apply elementwise [`PartialOrd::le`] on two vectors
-    fn vle<S: Simd>(simd: S, a: Self::Vector<S>, b: Self::Vector<S>) -> Self::Mask<S>;
+    fn vle<S: Simd>(a: Vector<S, Self>, b: Vector<S, Self>) -> Self::Mask<S>;
     /// Apply elementwise [`PartialOrd::gt`] on two vectors
-    fn vgt<S: Simd>(simd: S, a: Self::Vector<S>, b: Self::Vector<S>) -> Self::Mask<S>;
+    fn vgt<S: Simd>(a: Vector<S, Self>, b: Vector<S, Self>) -> Self::Mask<S>;
     /// Apply elementwise [`PartialOrd::ge`] on two vectors
-    fn vge<S: Simd>(simd: S, a: Self::Vector<S>, b: Self::Vector<S>) -> Self::Mask<S>;
+    fn vge<S: Simd>(a: Vector<S, Self>, b: Vector<S, Self>) -> Self::Mask<S>;
     /// Apply elementwise [`Ord::min`] to two vectors
-    fn vmin<S: Simd>(simd: S, a: Self::Vector<S>, b: Self::Vector<S>) -> Self::Vector<S>;
+    fn vmin<S: Simd>(a: Vector<S, Self>, b: Vector<S, Self>) -> Vector<S, Self>;
     /// Apply elementwise [`Ord::max`] on two vectors
-    fn vmax<S: Simd>(simd: S, a: Self::Vector<S>, b: Self::Vector<S>) -> Self::Vector<S>;
+    fn vmax<S: Simd>(a: Vector<S, Self>, b: Vector<S, Self>) -> Vector<S, Self>;
+    fn is_cmp_accelerated<S: Simd>() -> bool;
+    fn is_min_max_accelerated<S: Simd>() -> bool;
+}
+
+impl<S: Simd, T: VOrd> Vector<S, T> {
+    /// Apply elementwise [`PartialOrd::lt`] on two vectors
+    #[inline(always)]
+    pub fn lt(self, b: Self) -> T::Mask<S> {
+        T::vlt(self, b)
+    }
+    /// Apply elementwise [`PartialOrd::le`] on two vectors
+    #[inline(always)]
+    pub fn le(self, b: Self) -> T::Mask<S> {
+        T::vle(self, b)
+    }
+    /// Apply elementwise [`PartialOrd::gt`] on two vectors
+    #[inline(always)]
+    pub fn gt(self, b: Self) -> T::Mask<S> {
+        T::vgt(self, b)
+    }
+    /// Apply elementwise [`PartialOrd::ge`] on two vectors
+    #[inline(always)]
+    pub fn ge(self, b: Self) -> T::Mask<S> {
+        T::vge(self, b)
+    }
+    /// Apply elementwise [`Ord::min`] to two vectors
+    #[inline(always)]
+    pub fn min(self, b: Self) -> Self {
+        T::vmin(self, b)
+    }
+    /// Apply elementwise [`Ord::max`] on two vectors
+    #[inline(always)]
+    pub fn max(self, b: Self) -> Self {
+        T::vmax(self, b)
+    }
 }
 
 macro_rules! impl_vord {
-    ($ty: ty) => {
-        paste! {
+    ($($ty: ty),*) => {
+        $(paste! {
             impl VOrd for $ty {
                 #[inline(always)]
-                fn vlt<S: Simd>(simd: S, a: Self::Vector<S>, b: Self::Vector<S>) -> Self::Mask<S> {
-                    simd.[<less_than_ $ty s>](a, b)
+                fn vlt<S: Simd>(a: Vector<S, Self>, b: Vector<S, Self>) -> Self::Mask<S> {
+                    S::[<less_than_ $ty>](*a, *b)
                 }
                 #[inline(always)]
-                fn vle<S: Simd>(simd: S, a: Self::Vector<S>, b: Self::Vector<S>) -> Self::Mask<S> {
-                    simd.[<less_than_or_equal_ $ty s>](a, b)
+                fn vle<S: Simd>(a: Vector<S, Self>, b: Vector<S, Self>) -> Self::Mask<S> {
+                    S::[<less_than_or_equal_ $ty>](*a, *b)
                 }
                 #[inline(always)]
-                fn vgt<S: Simd>(simd: S, a: Self::Vector<S>, b: Self::Vector<S>) -> Self::Mask<S> {
-                    simd.[<greater_than_ $ty s>](a, b)
+                fn vgt<S: Simd>(a: Vector<S, Self>, b: Vector<S, Self>) -> Self::Mask<S> {
+                    S::[<greater_than_ $ty>](*a, *b)
                 }
                 #[inline(always)]
-                fn vge<S: Simd>(simd: S, a: Self::Vector<S>, b: Self::Vector<S>) -> Self::Mask<S> {
-                    simd.[<greater_than_or_equal_ $ty s>](a, b)
+                fn vge<S: Simd>(a: Vector<S, Self>, b: Vector<S, Self>) -> Self::Mask<S> {
+                    S::[<greater_than_or_equal_ $ty>](*a, *b)
                 }
                 #[inline(always)]
-                fn vmin<S: Simd>(simd: S, a: Self::Vector<S>, b: Self::Vector<S>) -> Self::Vector<S> {
-                    simd.[<min_ $ty s>](a, b)
+                fn vmin<S: Simd>(a: Vector<S, Self>, b: Vector<S, Self>) -> Vector<S, Self> {
+                    S::typed(S::[<min_ $ty>](*a, *b))
                 }
                 #[inline(always)]
-                fn vmax<S: Simd>(simd: S, a: Self::Vector<S>, b: Self::Vector<S>) -> Self::Vector<S> {
-                    simd.[<max_ $ty s>](a, b)
+                fn vmax<S: Simd>(a: Vector<S, Self>, b: Vector<S, Self>) -> Vector<S, Self> {
+                    S::typed(S::[<max_ $ty>](*a, *b))
+                }
+                #[inline(always)]
+                fn is_cmp_accelerated<S: Simd>() -> bool {
+                    S::[<less_than_ $ty _supported>]()
+                }
+                #[inline(always)]
+                fn is_min_max_accelerated<S: Simd>() -> bool {
+                    S::[<min_ $ty _supported>]()
                 }
             }
-        }
+        })*
     };
-    ($($ty: ty),*) => {
-        $(impl_vord!($ty);)*
-    }
 }
 
 impl_vord!(u8, i8, u16, i16, u32, i32, f32, u64, i64, f64);


### PR DESCRIPTION
Migrates to a custom backend with better ergonomics thanks to extensive type inference. Supports v2, v3, aarch64 and WASM.