### PR TITLE
Fix compile issues on targets without SIMD support

### DIFF
--- a/src/backend/arch.rs
+++ b/src/backend/arch.rs
@@ -39,7 +39,7 @@ impl Arch {
 
     pub fn dispatch<Op: WithSimd>(self, op: Op) -> Op::Output {
         match self {
-            Arch::Scalar => <Fallback as Simd>::vectorize(op),
+            Arch::Scalar => <crate::scalar::Fallback as Simd>::vectorize(op),
         }
     }
 }
@@ -85,6 +85,12 @@ macro_rules! feature_detected {
 #[allow(unused)]
 pub(crate) use feature_detected;
 
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    target_arch = "wasm32"
+))]
 macro_rules! impl_simd {
     ($($feature: tt),*) => {
         #[inline(always)]
@@ -171,6 +177,13 @@ macro_rules! impl_simd {
     }
     };
 }
+
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    target_arch = "wasm32"
+))]
 pub(crate) use impl_simd;
 
 use super::Simd;

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -322,6 +322,12 @@ pub trait Simd: Sized + seal::Sealed + 'static {
     declare_unop!(abs, i8, i16, i32, i64, f16, f32, f64);
 }
 
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    target_arch = "wasm32"
+))]
 macro_rules! impl_cmp_scalar {
     ($func: ident, $intrinsic: path, $($ty: ty: $mask_ty: ty),*) => {
         $(paste! {
@@ -344,6 +350,13 @@ macro_rules! impl_cmp_scalar {
         })*
     };
 }
+
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    target_arch = "wasm32"
+))]
 pub(crate) use impl_cmp_scalar;
 
 /// Tests that type inference works properly


### PR DESCRIPTION
Fixes compilation errors on targets with no SIMD support. This has to be manually tested due to no available GitHub runners.