### PR TITLE
Chore: Clean up conditional compilation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,6 +65,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "crunchy"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -185,9 +191,11 @@ version = "0.2.7"
 dependencies = [
  "approx",
  "bytemuck",
+ "cfg_aliases",
  "getrandom",
  "half",
  "macerator-macros",
+ "moddef",
  "num-traits",
  "paste",
  "pretty_assertions",
@@ -214,6 +222,12 @@ dependencies = [
  "cc",
  "walkdir",
 ]
+
+[[package]]
+name = "moddef"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e519fd9c6131c1c9a4a67f8bdc4f32eb4105b16c1468adea1b8e68c98c85ec4"
 
 [[package]]
 name = "num-traits"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ bytemuck = { version = "1.22.0", features = [
 ] }
 half = { version = "2.5.0", features = ["bytemuck", "num-traits"] }
 macerator-macros = { version = "0.1.1", path = "crates/macerator-macros" }
+moddef = "0.2"
 num-traits = "0.2.0"
 paste = "1"
 
@@ -35,6 +36,9 @@ half = { version = "2.4", features = ["bytemuck", "num-traits", "rand_distr"] }
 pretty_assertions = "1.4.0"
 rand = { version = "0.9.0" }
 wasm-bindgen-test = "0.3.0"
+
+[build-dependencies]
+cfg_aliases = "0.2"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 getrandom = { version = "0.3.1", features = ["wasm_js"] }

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,9 @@
+use cfg_aliases::cfg_aliases;
+
+fn main() {
+    cfg_aliases! {
+        x86: { any(target_arch = "x86", target_arch = "x86_64") },
+        aarch64: { target_arch = "aarch64" },
+        wasm32: { target_arch = "wasm32" }
+    }
+}

--- a/src/backend/arch/scalar.rs
+++ b/src/backend/arch/scalar.rs
@@ -1,0 +1,28 @@
+use crate::Simd;
+
+use super::WithSimd;
+
+#[derive(Debug, Clone, Copy)]
+#[non_exhaustive]
+#[repr(u8)]
+pub enum Arch {
+    Scalar,
+}
+
+impl Arch {
+    pub fn new() -> Self {
+        Self::Scalar
+    }
+
+    pub fn dispatch<Op: WithSimd>(self, op: Op) -> Op::Output {
+        match self {
+            Arch::Scalar => <crate::scalar::Fallback as Simd>::vectorize(op),
+        }
+    }
+}
+
+impl Default for Arch {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/tests/arithmetic.rs
+++ b/src/tests/arithmetic.rs
@@ -105,7 +105,7 @@ macro_rules! testgen_fma {
                     .zip(b.iter()).zip(c.iter())
                     .map(|((a, b), c)| a * b + c)
                     .collect::<Vec<_>>();
-                #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+                #[cfg(x86)]
                 {
                     use crate::backend::x86::*;
                     #[cfg(all(feature = "nightly", feature = "fp16"))]
@@ -127,7 +127,7 @@ macro_rules! testgen_fma {
                         assert_approx_eq(&out_ref, &out);
                     }
                 }
-                #[cfg(target_arch = "aarch64")]
+                #[cfg(aarch64)]
                 {
                     use crate::backend::aarch64::NeonFma;
                     if NeonFma::is_available() {
@@ -135,7 +135,7 @@ macro_rules! testgen_fma {
                         assert_approx_eq(&out_ref, &out);
                     }
                 }
-                #[cfg(target_arch = "wasm32")]
+                #[cfg(wasm32)]
                 {
                     use crate::backend::wasm32::Simd128;
                     let out = Simd128::run_vectorized(|| [<$test_fn _impl>]::<Simd128, $ty>(&a, &b, &c));

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -46,7 +46,7 @@ macro_rules! testgen_binop {
                     .zip(rhs.iter())
                     .map(|(a, b)| $reference(a, b))
                     .collect::<Vec<_>>();
-                #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+                #[cfg(x86)]
                 {
                     use $crate::backend::x86::*;
                     #[cfg(all(feature = "nightly", feature = "fp16"))]
@@ -68,7 +68,7 @@ macro_rules! testgen_binop {
                         assert_eq!(out_ref, out);
                     }
                 }
-                #[cfg(target_arch = "aarch64")]
+                #[cfg(aarch64)]
                 {
                     use $crate::backend::aarch64::NeonFma;
                     if NeonFma::is_available() {
@@ -76,7 +76,7 @@ macro_rules! testgen_binop {
                         assert_eq!(out_ref, out);
                     }
                 }
-                #[cfg(target_arch = "wasm32")]
+                #[cfg(wasm32)]
                 {
                     use crate::backend::wasm32::Simd128;
                     let out = Simd128::run_vectorized(|| [<$test_fn _impl>]::<Simd128, $ty>(&lhs, &rhs));
@@ -165,7 +165,7 @@ macro_rules! testgen_unop {
 
                 let a = $crate::tests::random::<$ty>(NumCast::from($lo).unwrap(), NumCast::from($hi).unwrap());
                 let out_ref = a.iter().map(|a| $ty::$reference(*a)).collect::<Vec<_>>();
-                #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+                #[cfg(x86)]
                 {
                     use $crate::backend::x86::*;
                     #[cfg(all(feature = "nightly", feature = "fp16"))]
@@ -187,7 +187,7 @@ macro_rules! testgen_unop {
                         $assert(&out_ref, &out);
                     }
                 }
-                #[cfg(target_arch = "aarch64")]
+                #[cfg(aarch64)]
                 {
                     use $crate::backend::aarch64::NeonFma;
                     if NeonFma::is_available() {
@@ -195,7 +195,7 @@ macro_rules! testgen_unop {
                         $assert(&out_ref, &out);
                     }
                 }
-                #[cfg(target_arch = "wasm32")]
+                #[cfg(wasm32)]
                 {
                     use crate::backend::wasm32::Simd128;
                     let out = Simd128::run_vectorized(|| [<$test_fn _impl>]::<Simd128, $ty>(&a));

--- a/src/tests/ord.rs
+++ b/src/tests/ord.rs
@@ -138,7 +138,7 @@ macro_rules! testgen_min_max {
                         assert_eq!(out_ref, out);
                     }
                 }
-                #[cfg(aarch64)]
+                #[cfg(wasm32)]
                 {
                     use crate::backend::wasm32::Simd128;
                     let out = Simd128::run_vectorized(|| [<$test_fn _impl>]::<Simd128, $ty>(&lhs, &rhs));

--- a/src/tests/ord.rs
+++ b/src/tests/ord.rs
@@ -51,7 +51,7 @@ macro_rules! testgen_cmp {
                     .zip(rhs.iter())
                     .map(|(a, b)| $ty::$reference(a, b))
                     .collect::<Vec<_>>();
-                #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+                #[cfg(x86)]
                 {
                     use $crate::backend::x86::*;
                     #[cfg(all(feature = "nightly", feature = "fp16"))]
@@ -73,7 +73,7 @@ macro_rules! testgen_cmp {
                         assert_eq!(out_ref, out);
                     }
                 }
-                #[cfg(target_arch = "aarch64")]
+                #[cfg(aarch64)]
                 {
                     use $crate::backend::aarch64::NeonFma;
                     if NeonFma::is_available() {
@@ -81,7 +81,7 @@ macro_rules! testgen_cmp {
                         assert_eq!(out_ref, out);
                     }
                 }
-                #[cfg(target_arch = "wasm32")]
+                #[cfg(wasm32)]
                 {
                     use crate::backend::wasm32::Simd128;
                     let out = Simd128::run_vectorized(|| [<$test_fn _impl>]::<Simd128, $ty>(&lhs, &rhs));
@@ -108,7 +108,7 @@ macro_rules! testgen_min_max {
                     .zip(rhs.iter())
                     .map(|(a, b)| $ty::$reference(*a, *b))
                     .collect::<Vec<_>>();
-                #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+                #[cfg(x86)]
                 {
                     use $crate::backend::x86::*;
                     #[cfg(all(feature = "nightly", feature = "fp16"))]
@@ -130,7 +130,7 @@ macro_rules! testgen_min_max {
                         assert_eq!(out_ref, out);
                     }
                 }
-                #[cfg(target_arch = "aarch64")]
+                #[cfg(aarch64)]
                 {
                     use $crate::backend::aarch64::NeonFma;
                     if NeonFma::is_available() {
@@ -138,7 +138,7 @@ macro_rules! testgen_min_max {
                         assert_eq!(out_ref, out);
                     }
                 }
-                #[cfg(target_arch = "wasm32")]
+                #[cfg(aarch64)]
                 {
                     use crate::backend::wasm32::Simd128;
                     let out = Simd128::run_vectorized(|| [<$test_fn _impl>]::<Simd128, $ty>(&lhs, &rhs));


### PR DESCRIPTION
Cleans up the conditionally compiled modules using `cfg_aliases` and `moddef`.
Moves fallback `Arch` to a separate module for clarity.