### PR TITLE
feat: Allow using AVX-512 on stable if rustc is at version 1.89 or higher

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,6 +13,8 @@ jobs:
         os: [ubuntu-latest, macos-latest, ubuntu-24.04-arm]
     steps:
     - uses: actions/checkout@v4
+    - name: Update
+      run: rustup update
     - name: Build
       run: cargo build --verbose
     - name: Run tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bitflags"
@@ -25,24 +25,24 @@ checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "bumpalo"
-version = "3.17.0"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "bytemuck"
-version = "1.23.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9134a6ef01ce4b366b50689c94f82c14bc72bc5d0386829828a2e2752ef7958c"
+checksum = "5c76a5792e44e4abe34d3abf15636779261d45a7450612059293d1d2cfc63422"
 dependencies = [
  "bytemuck_derive",
 ]
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.9.3"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ecc273b49b3205b83d648f0690daa588925572cc5063745bfe547fe7ec8e1a1"
+checksum = "4f154e572231cb6ba2bd1176980827e3d5dc04cc183a75dea38109fbdd672d29"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -51,18 +51,18 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.23"
+version = "1.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4ac86a9e5bc1e2b3449ab9d7d3a6a405e3d1bb28d7b9be8614f55846ae3766"
+checksum = "c3a42d84bb6b69d3a8b3eaacf0d88f179e1929695e1ad012b6cf64d9caaa5fd2"
 dependencies = [
  "shlex",
 ]
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "cfg_aliases"
@@ -72,9 +72,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "crunchy"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "darling"
@@ -169,9 +169,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "libm"
@@ -225,9 +225,9 @@ dependencies = [
 
 [[package]]
 name = "moddef"
-version = "0.2.6"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e519fd9c6131c1c9a4a67f8bdc4f32eb4105b16c1468adea1b8e68c98c85ec4"
+checksum = "4a0b3262dc837d2513fe2ef31ff8461352ef932dcca31ba0c0abe33547cf6b9b"
 
 [[package]]
 name = "num-traits"
@@ -290,15 +290,15 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha",
  "rand_core",
@@ -356,9 +356,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.101"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -593,18 +593,18 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,6 +200,7 @@ dependencies = [
  "paste",
  "pretty_assertions",
  "rand",
+ "rustc_version",
  "wasm-bindgen-test",
 ]
 
@@ -334,6 +335,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -341,6 +351,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "shlex"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,14 +19,14 @@ nightly = []
 std = []
 
 [dependencies]
-bytemuck = { version = "1.22.0", features = [
+bytemuck = { version = "1.23.1", features = [
     "aarch64_simd",
     "wasm_simd",
     "avx512_simd",
 ] }
 half = { version = "2.5.0", features = ["bytemuck", "num-traits"] }
 macerator-macros = { version = "0.1.2", path = "crates/macerator-macros" }
-moddef = "0.2"
+moddef = "0.3"
 num-traits = "0.2.0"
 paste = "1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,9 @@ rust-version = "1.81"
 version = "0.2.8"
 
 [features]
-default = ["std"]
+default = ["std", "avx512"]
 
+avx512 = []
 fp16 = ["nightly"]
 nightly = []
 std = []
@@ -34,11 +35,12 @@ paste = "1"
 approx = "0.5"
 half = { version = "2.4", features = ["bytemuck", "num-traits", "rand_distr"] }
 pretty_assertions = "1.4.0"
-rand = { version = "0.9.0" }
+rand = { version = "0.9" }
 wasm-bindgen-test = "0.3.0"
 
 [build-dependencies]
 cfg_aliases = "0.2"
+rustc_version = "0.4"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 getrandom = { version = "0.3.1", features = ["wasm_js"] }

--- a/build.rs
+++ b/build.rs
@@ -24,7 +24,6 @@ fn main() {
 
     cfg_aliases! {
         x86: { any(target_arch = "x86", target_arch = "x86_64") },
-        avx512: { all(target_arch = "x86_64", feature = "avx512") },
         fp16: { all(target_arch = "x86_64", feature = "fp16", feature = "nightly") },
         aarch64: { target_arch = "aarch64" },
         wasm32: { target_arch = "wasm32" },

--- a/build.rs
+++ b/build.rs
@@ -1,9 +1,30 @@
+use std::env;
+
 use cfg_aliases::cfg_aliases;
 
 fn main() {
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
+    println!("cargo::rustc-check-cfg=cfg(avx512)");
+    println!("cargo::rustc-check-cfg=cfg(avx512_nightly)");
+
+    if target_arch == "x86_64" {
+        let version = rustc_version::version().unwrap();
+        let avx512_feature_enabled = env::var("CARGO_FEATURE_AVX512").is_ok();
+        let nightly_feature_enabled = env::var("CARGO_FEATURE_NIGHTLY").is_ok();
+
+        let avx512_stable_version = rustc_version::Version::new(1, 89, 0);
+
+        if (version >= avx512_stable_version && avx512_feature_enabled) || nightly_feature_enabled {
+            println!("cargo:rustc-cfg=avx512");
+        }
+        if version < avx512_stable_version && nightly_feature_enabled {
+            println!("cargo:rustc-cfg=avx512_nightly")
+        }
+    }
+
     cfg_aliases! {
         x86: { any(target_arch = "x86", target_arch = "x86_64") },
-        avx512: { all(target_arch = "x86_64", feature = "nightly") },
+        avx512: { all(target_arch = "x86_64", feature = "avx512") },
         fp16: { all(target_arch = "x86_64", feature = "fp16", feature = "nightly") },
         aarch64: { target_arch = "aarch64" },
         wasm32: { target_arch = "wasm32" },

--- a/src/backend/x86/mod.rs
+++ b/src/backend/x86/mod.rs
@@ -4,6 +4,8 @@
     clippy::transmute_int_to_float,
     unused_unsafe
 )]
+// Lint can't detect the build script version check
+#![cfg_attr(all(avx512, not(avx512_nightly)), allow(incompatible_msrv))]
 
 pub mod v2;
 pub mod v3;

--- a/src/backend/x86/v4.rs
+++ b/src/backend/x86/v4.rs
@@ -35,6 +35,7 @@ macro_rules! with_ty_cmp {
     }
 }
 
+#[cfg(fp16)]
 macro_rules! impl_cmp_fp16 {
     ($func: ident, $op: expr, $($ty: ty),*) => {
         $(paste! {
@@ -152,9 +153,9 @@ impl FP16Ext for FP16Fallback {
     }
 }
 
-#[cfg(feature = "fp16")]
+#[cfg(fp16)]
 impl Sealed for FP16Intrinsic {}
-#[cfg(feature = "fp16")]
+#[cfg(fp16)]
 impl FP16Ext for FP16Intrinsic {
     type Register = __m512;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(avx512, feature(avx512_target_feature, stdarch_x86_avx512))]
+#![cfg_attr(avx512_nightly, feature(avx512_target_feature, stdarch_x86_avx512))]
 #![cfg_attr(fp16, feature(stdarch_x86_avx512_f16))]
 #![cfg_attr(
     loong64,


### PR DESCRIPTION
Adds a check to the build script that enables `avx512` *either* if `nightly` is enabled, or rustc is 1.89.0 or greater. This allows for stable AVX-512 without a breaking MSRV bump for all platfoms.