### PR TITLE
chore: Unconditionally enable `no_std`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,13 @@
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 #![cfg_attr(avx512_nightly, feature(avx512_target_feature, stdarch_x86_avx512))]
 #![cfg_attr(fp16, feature(stdarch_x86_avx512_f16))]
 #![cfg_attr(
     loong64,
     feature(stdarch_loongarch, stdarch_loongarch_feature_detection)
 )]
+
+#[cfg(feature = "std")]
+extern crate std;
 
 mod arithmetic;
 pub(crate) mod backend;

--- a/src/tests/arithmetic.rs
+++ b/src/tests/arithmetic.rs
@@ -1,3 +1,5 @@
+use std::{vec, vec::Vec};
+
 use crate::scalar::Fallback;
 
 use bytemuck::Zeroable;

--- a/src/tests/bitwise.rs
+++ b/src/tests/bitwise.rs
@@ -1,4 +1,5 @@
 use core::ops::Not;
+use std::vec::Vec;
 
 use crate::{Simd, VBitAnd, VBitNot, VBitOr, VBitXor};
 

--- a/src/tests/macro_tests.rs
+++ b/src/tests/macro_tests.rs
@@ -4,6 +4,8 @@
     clippy::needless_lifetimes
 )]
 
+use std::vec::Vec;
+
 use crate as macerator;
 use macerator_macros::with_simd;
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,4 +1,5 @@
 use core::fmt::Debug;
+use std::{vec, vec::Vec};
 
 use approx::{assert_relative_eq, RelativeEq};
 use bytemuck::Zeroable;

--- a/src/tests/ord.rs
+++ b/src/tests/ord.rs
@@ -1,3 +1,5 @@
+use std::{vec, vec::Vec};
+
 use crate::{
     tests::{binop, test_binop},
     vload_unaligned, Mask, Scalar, Simd, VEq, VOrd, Vector,

--- a/src/tests/unary.rs
+++ b/src/tests/unary.rs
@@ -1,4 +1,5 @@
 use core::fmt::Debug;
+use std::vec::Vec;
 
 use approx::{assert_relative_eq, RelativeEq};
 use num_traits::{Float, NumCast};


### PR DESCRIPTION
Unconditionally enable `no_std` to avoid potential prelude issues.