### PR TITLE
ci: Add Miri CI workflow

### DIFF
--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -1,0 +1,55 @@
+name: Miri
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  miri:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # x86_64
+          - target: x86_64-unknown-linux-gnu
+            rustflags: ""
+            features: nightly
+          # x86_64-v2
+          - target: x86_64-unknown-linux-gnu
+            rustflags: "-C target-feature=+sse,+sse2,+fxsr,+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt"
+            features: nightly
+          # x86_64-v3
+          - target: x86_64-unknown-linux-gnu
+            rustflags: "-C target-feature=+sse,+sse2,+fxsr,+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+avx,+avx2,+bmi1,+bmi2,+fma,+lzcnt,+f16c"
+            features: miri-x86_v3
+          # x86_64-v4
+          - target: x86_64-unknown-linux-gnu
+            rustflags: "-C target-feature=+sse,+sse2,+fxsr,+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+avx,+avx2,+bmi1,+bmi2,+fma,+lzcnt,+f16c,+avx512f,+avx512bw,+avx512cd,+avx512dq,+avx512vl"
+            features: miri-x86_v4
+          # aarch64
+          - target: aarch64-unknown-linux-gnu
+            rustflags: "-C target-feature=+neon"
+            features: nightly
+          # loongarch64, no +lasx because Miri has no support at all
+          - target: loongarch64-unknown-linux-gnu
+            rustflags: "-C target-feature=+lsx"
+            features: nightly
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Miri
+        run: |
+          rustup toolchain install nightly --component miri
+          rustup override set nightly
+          rustup target add ${{ matrix.target }}
+          cargo miri setup
+      - name: Run Miri tests
+        run: cargo miri test --target ${{ matrix.target }} --verbose --features ${{ matrix.features }} --release
+        env:
+          RUSTFLAGS: ${{ matrix.rustflags }}
+          MIRIFLAGS: -Zmiri-strict-provenance

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,10 @@ fp16 = ["nightly"]
 nightly = []
 std = []
 
+# Internal testing features to gate tests with MIRI
+miri-x86_v3 = []
+miri-x86_v4 = []
+
 [dependencies]
 bytemuck = { version = "1.23.1", features = [
     "aarch64_simd",

--- a/build.rs
+++ b/build.rs
@@ -31,5 +31,8 @@ fn main() {
 
         // Workaround for Safari
         relaxed_simd: { all(target_arch = "wasm32", target_feature = "simd128", target_feature = "relaxed-simd") },
+
+        x86_v3: { feature = "miri-x86_v3" },
+        x86_v4: { feature = "miri-x86_v4" },
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,10 @@
 #![no_std]
 #![cfg_attr(avx512_nightly, feature(avx512_target_feature, stdarch_x86_avx512))]
 #![cfg_attr(fp16, feature(stdarch_x86_avx512_f16))]
+#![cfg_attr(loong64, feature(stdarch_loongarch))]
 #![cfg_attr(
-    loong64,
-    feature(stdarch_loongarch, stdarch_loongarch_feature_detection)
+    all(loong64, feature = "std"),
+    feature(stdarch_loongarch_feature_detection)
 )]
 
 #[cfg(feature = "std")]

--- a/src/tests/arithmetic.rs
+++ b/src/tests/arithmetic.rs
@@ -55,6 +55,7 @@ testgen_binop!(
     i8,
     u16,
     i16,
+    #[cfg_attr(all(miri, any(x86_v3, x86_v4)), ignore)]
     f16,
     u32,
     i32,
@@ -71,6 +72,7 @@ testgen_binop!(
     i8,
     u16,
     i16,
+    #[cfg_attr(all(miri, any(x86_v3, x86_v4)), ignore)]
     f16,
     u32,
     i32,
@@ -79,7 +81,14 @@ testgen_binop!(
     i64,
     f64
 );
-testgen_binop!(test_div, |a, b| a / b, f16, f32, f64);
+testgen_binop!(
+    test_div,
+    |a, b| a / b,
+    #[cfg_attr(all(miri, any(x86_v3, x86_v4)), ignore)]
+    f16,
+    f32,
+    f64
+);
 testgen_binop!(
     test_mul,
     |a, b| a * b,
@@ -87,6 +96,7 @@ testgen_binop!(
     i8,
     u16,
     i16,
+    #[cfg_attr(all(miri, any(x86_v3, x86_v4)), ignore)]
     f16,
     u32,
     i32,

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -41,8 +41,9 @@ fn assert_eq<T: PartialEq + Debug>(lhs: &[T], rhs: &[T]) {
 }
 
 macro_rules! testgen_binop {
-    ($test_fn: ident, $reference: expr, $($ty: ty),*) => {
+    ($test_fn: ident, $reference: expr, $($(#[$meta:meta])* $ty: ty),*) => {
         $(::paste::paste! {
+            $(#[$meta])*
             #[::wasm_bindgen_test::wasm_bindgen_test(unsupported = test)]
             fn [<$test_fn _ $ty>]() {
                 use num_traits::NumCast;
@@ -184,8 +185,9 @@ macro_rules! unop {
 pub(crate) use unop;
 
 macro_rules! testgen_unop {
-    ($test_fn: ident, $reference: expr, $lo: expr, $hi: expr, $assert: ident, $($ty: ty),*) => {
+    ($test_fn: ident, $reference: expr, $lo: expr, $hi: expr, $assert: ident, $($(#[$meta:meta])* $ty: ty),*) => {
         $(::paste::paste! {
+            $(#[$meta])*
             #[::wasm_bindgen_test::wasm_bindgen_test(unsupported = test)]
             fn [<$test_fn _ $ty>]() {
                 use num_traits::NumCast;

--- a/src/tests/ord.rs
+++ b/src/tests/ord.rs
@@ -40,8 +40,9 @@ macro_rules! cmp_op {
 }
 
 macro_rules! testgen_cmp {
-    ($test_fn: ident, $reference: expr, $($ty: ty),*) => {
+    ($test_fn: ident, $reference: expr, $($(#[$meta:meta])* $ty: ty),*) => {
         $(::paste::paste! {
+            $(#[$meta])*
             #[::wasm_bindgen_test::wasm_bindgen_test(unsupported = test)]
             fn [<$test_fn _ $ty>]() {
                 use num_traits::NumCast;
@@ -116,8 +117,9 @@ macro_rules! testgen_cmp {
 }
 
 macro_rules! testgen_min_max {
-    ($test_fn: ident, $reference: expr, $($ty: ty),*) => {
+    ($test_fn: ident, $reference: expr, $($(#[$meta:meta])* $ty: ty),*) => {
         $(::paste::paste! {
+            $(#[$meta])*
             #[::wasm_bindgen_test::wasm_bindgen_test(unsupported = test)]
             fn [<$test_fn _ $ty>]() {
                 use num_traits::NumCast;
@@ -233,10 +235,115 @@ fn test_max_impl<S: Simd, T: VOrd>(lhs: &[T], rhs: &[T]) -> Vec<T> {
     test_binop::<S, T, VOrdOp<T>>(lhs, rhs)
 }
 
-testgen_cmp!(test_eq, eq, u8, i8, u16, i16, u32, i32, f32, u64, i64, f64);
-testgen_cmp!(test_lt, lt, u8, i8, u16, i16, u32, i32, f32, u64, i64, f64);
-testgen_cmp!(test_gt, gt, u8, i8, u16, i16, u32, i32, f32, u64, i64, f64);
-testgen_cmp!(test_le, le, u8, i8, u16, i16, u32, i32, f32, u64, i64, f64);
-testgen_cmp!(test_ge, ge, u8, i8, u16, i16, u32, i32, f32, u64, i64, f64);
-testgen_min_max!(test_min, min, u8, i8, u16, i16, u32, i32, f32, u64, i64, f64);
-testgen_min_max!(test_max, max, u8, i8, u16, i16, u32, i32, f32, u64, i64, f64);
+testgen_cmp!(
+    test_eq,
+    eq,
+    u8,
+    i8,
+    u16,
+    i16,
+    u32,
+    i32,
+    #[cfg_attr(all(miri, x86_v4), ignore)]
+    f32,
+    u64,
+    i64,
+    #[cfg_attr(all(miri, x86_v4), ignore)]
+    f64
+);
+testgen_cmp!(
+    test_lt,
+    lt,
+    u8,
+    i8,
+    u16,
+    i16,
+    u32,
+    i32,
+    #[cfg_attr(all(miri, x86_v4), ignore)]
+    f32,
+    u64,
+    i64,
+    #[cfg_attr(all(miri, x86_v4), ignore)]
+    f64
+);
+testgen_cmp!(
+    test_gt,
+    gt,
+    u8,
+    i8,
+    u16,
+    i16,
+    u32,
+    i32,
+    #[cfg_attr(all(miri, x86_v4), ignore)]
+    f32,
+    u64,
+    i64,
+    #[cfg_attr(all(miri, x86_v4), ignore)]
+    f64
+);
+testgen_cmp!(
+    test_le,
+    le,
+    u8,
+    i8,
+    u16,
+    i16,
+    u32,
+    i32,
+    #[cfg_attr(all(miri, x86_v4), ignore)]
+    f32,
+    u64,
+    i64,
+    #[cfg_attr(all(miri, x86_v4), ignore)]
+    f64
+);
+testgen_cmp!(
+    test_ge,
+    ge,
+    u8,
+    i8,
+    u16,
+    i16,
+    u32,
+    i32,
+    #[cfg_attr(all(miri, x86_v4), ignore)]
+    f32,
+    u64,
+    i64,
+    #[cfg_attr(all(miri, x86_v4), ignore)]
+    f64
+);
+testgen_min_max!(
+    test_min,
+    min,
+    u8,
+    i8,
+    u16,
+    i16,
+    u32,
+    i32,
+    #[cfg_attr(all(miri, any(aarch64, x86_v4)), ignore)]
+    f32,
+    u64,
+    i64,
+    #[cfg_attr(all(miri, any(aarch64, x86_v4)), ignore)]
+    f64
+);
+testgen_min_max!(
+    test_max,
+    max,
+    u8,
+    i8,
+    u16,
+    i16,
+    u32,
+    i32,
+    #[cfg_attr(all(miri, any(aarch64, x86_v4)), ignore)]
+    f32,
+    u64,
+    i64,
+    #[cfg_attr(all(miri, any(aarch64, x86_v4)), ignore)]
+    f64
+);

--- a/src/tests/reduce.rs
+++ b/src/tests/reduce.rs
@@ -89,8 +89,9 @@ fn test_reduce_op<S: Simd, T: Scalar + Debug, Op: ReduceOp<T>>(a: &[T], default:
 }
 
 macro_rules! testgen_reduce {
-    ($test_fn: ident, $reference: expr, $default: expr, $lo: expr, $hi: expr, $size: expr, $assert: ident, $($ty: ty),*) => {
+    ($test_fn: ident, $reference: expr, $default: expr, $lo: expr, $hi: expr, $size: expr, $assert: ident, $($(#[$meta:meta])* $ty: ty),*) => {
         $(::paste::paste! {
+            $(#[$meta])*
             #[::wasm_bindgen_test::wasm_bindgen_test(unsupported = test)]
             fn [<$test_fn _ $ty>]() {
                 use num_traits::NumCast;
@@ -168,7 +169,9 @@ testgen_reduce!(
     100,
     128,
     assert_approx_eq_sum,
+    #[cfg_attr(all(miri, aarch64), ignore)]
     f32,
+    #[cfg_attr(all(miri, aarch64), ignore)]
     f64
 );
 
@@ -236,7 +239,9 @@ testgen_reduce!(
     50,
     128,
     assert_eq,
+    #[cfg_attr(all(miri, aarch64), ignore)]
     f32,
+    #[cfg_attr(all(miri, aarch64), ignore)]
     f64
 );
 
@@ -276,7 +281,9 @@ testgen_reduce!(
     50,
     128,
     assert_eq,
+    #[cfg_attr(all(miri, aarch64), ignore)]
     f32,
+    #[cfg_attr(all(miri, aarch64), ignore)]
     f64
 );
 

--- a/src/tests/unary.rs
+++ b/src/tests/unary.rs
@@ -35,5 +35,15 @@ fn assert_approx_eq_recip<T: RelativeEq<Epsilon = T> + Debug + NumCast + Copy>(
     }
 }
 
-testgen_unop!(test_recip, recip, 1, 100, assert_approx_eq_recip, f32, f64);
+testgen_unop!(
+    test_recip,
+    recip,
+    1,
+    100,
+    assert_approx_eq_recip,
+    #[cfg_attr(all(miri, any(aarch64, x86_v4)), ignore)]
+    f32,
+    #[cfg_attr(all(miri, any(aarch64, x86_v4)), ignore)]
+    f64
+);
 testgen_unop!(test_abs, abs, -100, 100, assert_eq, i8, i16, i32, f32, f64);


### PR DESCRIPTION
Adds workflow to run MIRI on most supported targets, and selectively excludes tests with unsupported intrinsics.