### PR TITLE
Add crucial missing inline(always), caused intrinsics to fail to be inlined

### DIFF
--- a/crates/macerator-macros/src/lib.rs
+++ b/crates/macerator-macros/src/lib.rs
@@ -152,6 +152,7 @@ fn with_simd_impl(attr: TokenStream, item: TokenStream) -> Result<TokenStream, s
         }
 
         #(#attrs)*
+        #[inline(always)]
         #inner_fn_sig #block
     })
 }


### PR DESCRIPTION
This inline(always) is the crucial one, on which inlining of intrinsics for at least some functions seemed to hinge.

Without this, i needed fat LTO to get decent performance. This makes it compile correctly without fat LTO.

Before, 40% samples of my burn-flex project:
<img width="1180" height="171" alt="image" src="https://github.com/user-attachments/assets/1a0092df-5b58-4eed-9f9a-427327ca4f44" />

After, 1.2% of samples:
<img width="1180" height="171" alt="image" src="https://github.com/user-attachments/assets/4bae7223-35c6-4fb2-b5da-9bf779bb9a28" />
