### PR TITLE
fix: Make `run_vectorized` and `dispatch` unsafe to avoid unsoundness

### DIFF
--- a/crates/macerator-macros/src/lib.rs
+++ b/crates/macerator-macros/src/lib.rs
@@ -34,7 +34,9 @@ fn with_simd_impl(attr: TokenStream, item: TokenStream) -> Result<TokenStream, s
         }
     };
 
-    let arch = opts.arch.unwrap_or(parse_quote!(macerator::Arch::new()));
+    let arch = opts
+        .arch
+        .unwrap_or(parse_quote!(macerator::AutoArch::new()));
     let func = syn::parse2::<syn::ItemFn>(item)?;
 
     let ItemFn {

--- a/src/backend/aarch64.rs
+++ b/src/backend/aarch64.rs
@@ -535,7 +535,7 @@ where
     impl_reduce_scalar!(reduce_min, min, u64, i64);
     impl_reduce_scalar!(reduce_max, max, u64, i64);
 
-    fn vectorize<Op: WithSimd>(op: Op) -> Op::Output {
+    unsafe fn vectorize<Op: WithSimd>(op: Op) -> Op::Output {
         struct Impl<Op, FP16> {
             op: Op,
             _fp16: PhantomData<FP16>,
@@ -758,12 +758,12 @@ where
 }
 
 trait NeonRun {
-    fn run_vectorized<F: NullaryFnOnce>(f: F) -> F::Output;
+    unsafe fn run_vectorized<F: NullaryFnOnce>(f: F) -> F::Output;
 }
 
 impl NeonRun for NeonFma {
     #[inline(always)]
-    fn run_vectorized<F: NullaryFnOnce>(f: F) -> F::Output {
+    unsafe fn run_vectorized<F: NullaryFnOnce>(f: F) -> F::Output {
         NeonFma::run_vectorized(f)
     }
 }
@@ -771,7 +771,7 @@ impl NeonRun for NeonFma {
 #[cfg(feature = "fp16")]
 impl NeonRun for NeonFP16 {
     #[inline(always)]
-    fn run_vectorized<F: NullaryFnOnce>(f: F) -> F::Output {
+    unsafe fn run_vectorized<F: NullaryFnOnce>(f: F) -> F::Output {
         NeonFP16::run_vectorized(f)
     }
 }

--- a/src/backend/arch.rs
+++ b/src/backend/arch.rs
@@ -8,6 +8,30 @@ moddef::moddef!(
     }
 );
 
+/// Auto-selected [`Arch`], implements a safe version of [`Arch::dispatch`] by
+/// ensuring it can only be initialized with the correct feature checks.
+pub struct AutoArch(Arch);
+
+impl AutoArch {
+    /// Construct a new [`AutoArch`] by automatically detecting the newest
+    /// supported [`Arch`]
+    pub fn new() -> Self {
+        Self(Arch::detect())
+    }
+
+    /// Dispatch a function on the inner [`Arch`]
+    pub fn dispatch<Op: WithSimd>(self, op: Op) -> Op::Output {
+        // Safety: auto-detection enforces feature support
+        unsafe { self.0.dispatch(op) }
+    }
+}
+
+impl Default for AutoArch {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[cfg(all(feature = "std", x86))]
 #[macro_export]
 macro_rules! feature_detected {
@@ -73,61 +97,64 @@ macro_rules! impl_simd {
         }
 
         /// Vectorizes the given function as if the CPU features for this type were
-    /// applied to it.
-    ///
-    /// # Note
-    /// For the vectorization to work properly, the given function must be
-    /// inlined. Consider marking it as `#[inline(always)]`
-    #[inline(always)]
-    pub fn run_vectorized<F: NullaryFnOnce>(f: F) -> F::Output {
-        $(#[target_feature(enable = $feature)])*
-        #[inline]
-        #[allow(clippy::too_many_arguments)]
-        unsafe fn imp_fastcall<F: NullaryFnOnce>(
-            f0: ::core::mem::MaybeUninit<::core::primitive::usize>,
-            f1: ::core::mem::MaybeUninit<::core::primitive::usize>,
-            f2: ::core::mem::MaybeUninit<::core::primitive::usize>,
-            f3: ::core::mem::MaybeUninit<::core::primitive::usize>,
-            f4: ::core::mem::MaybeUninit<::core::primitive::usize>,
-            f5: ::core::mem::MaybeUninit<::core::primitive::usize>,
-            f6: ::core::mem::MaybeUninit<::core::primitive::usize>,
-            f7: ::core::mem::MaybeUninit<::core::primitive::usize>,
-        ) -> F::Output {
-            let f: F = unsafe { core::mem::transmute_copy(&[f0, f1, f2, f3, f4, f5, f6, f7]) };
-            f.call()
-        }
-        $(#[target_feature(enable = $feature)])*
-        #[inline]
-        unsafe fn imp<F: NullaryFnOnce>(f: F) -> F::Output {
-            f.call()
-        }
-        if const {
-            (::core::mem::size_of::<F>() <= 8 * ::core::mem::size_of::<::core::primitive::usize>())
-        } {
-            union Pad<T> {
-                t: ::core::mem::ManuallyDrop<T>,
-                __u: ::core::mem::MaybeUninit<[usize; 8]>,
+        /// applied to it.
+        ///
+        /// # Note
+        /// For the vectorization to work properly, the given function must be
+        /// inlined. Consider marking it as `#[inline(always)]`
+        ///
+        /// # Safety
+        /// Required features for this arch must be available.
+        #[inline(always)]
+        pub unsafe fn run_vectorized<F: NullaryFnOnce>(f: F) -> F::Output {
+            $(#[target_feature(enable = $feature)])*
+            #[inline]
+            #[allow(clippy::too_many_arguments)]
+            unsafe fn imp_fastcall<F: NullaryFnOnce>(
+                f0: ::core::mem::MaybeUninit<::core::primitive::usize>,
+                f1: ::core::mem::MaybeUninit<::core::primitive::usize>,
+                f2: ::core::mem::MaybeUninit<::core::primitive::usize>,
+                f3: ::core::mem::MaybeUninit<::core::primitive::usize>,
+                f4: ::core::mem::MaybeUninit<::core::primitive::usize>,
+                f5: ::core::mem::MaybeUninit<::core::primitive::usize>,
+                f6: ::core::mem::MaybeUninit<::core::primitive::usize>,
+                f7: ::core::mem::MaybeUninit<::core::primitive::usize>,
+            ) -> F::Output {
+                let f: F = unsafe { core::mem::transmute_copy(&[f0, f1, f2, f3, f4, f5, f6, f7]) };
+                f.call()
             }
-            let f = Pad {
-                t: ::core::mem::ManuallyDrop::new(f),
-            };
-            let p = (&f) as *const _ as *const ::core::mem::MaybeUninit<usize>;
-            unsafe {
-                imp_fastcall::<F>(
-                    *p.add(0),
-                    *p.add(1),
-                    *p.add(2),
-                    *p.add(3),
-                    *p.add(4),
-                    *p.add(5),
-                    *p.add(6),
-                    *p.add(7),
-                )
+            $(#[target_feature(enable = $feature)])*
+            #[inline]
+            unsafe fn imp<F: NullaryFnOnce>(f: F) -> F::Output {
+                f.call()
             }
-        } else {
-            unsafe { imp(f) }
+            if const {
+                (::core::mem::size_of::<F>() <= 8 * ::core::mem::size_of::<::core::primitive::usize>())
+            } {
+                union Pad<T> {
+                    t: ::core::mem::ManuallyDrop<T>,
+                    __u: ::core::mem::MaybeUninit<[usize; 8]>,
+                }
+                let f = Pad {
+                    t: ::core::mem::ManuallyDrop::new(f),
+                };
+                let p = (&f) as *const _ as *const ::core::mem::MaybeUninit<usize>;
+                unsafe {
+                    imp_fastcall::<F>(
+                        *p.add(0),
+                        *p.add(1),
+                        *p.add(2),
+                        *p.add(3),
+                        *p.add(4),
+                        *p.add(5),
+                        *p.add(6),
+                        *p.add(7),
+                    )
+                }
+            } else {
+                unsafe { imp(f) }
+            }
         }
-    }
     };
 }
 

--- a/src/backend/arch/aarch64.rs
+++ b/src/backend/arch/aarch64.rs
@@ -16,7 +16,7 @@ pub enum Arch {
 }
 
 impl Arch {
-    pub fn new() -> Self {
+    pub fn detect() -> Self {
         #[cfg(feature = "fp16")]
         if NeonFP16::is_available() {
             return Self::NeonF16;
@@ -28,7 +28,11 @@ impl Arch {
         }
     }
 
-    pub fn dispatch<Op: WithSimd>(self, op: Op) -> Op::Output {
+    /// Dispatch a function on this [`Arch`]
+    ///
+    /// # Safety
+    /// Required features for the [`Arch`] must be available.
+    pub unsafe fn dispatch<Op: WithSimd>(self, op: Op) -> Op::Output {
         match self {
             Arch::Scalar => <Fallback as Simd>::vectorize(op),
             Arch::NeonFma => <NeonFma as Simd>::vectorize(op),
@@ -40,6 +44,6 @@ impl Arch {
 
 impl Default for Arch {
     fn default() -> Self {
-        Self::new()
+        Self::detect()
     }
 }

--- a/src/backend/arch/loong64.rs
+++ b/src/backend/arch/loong64.rs
@@ -18,7 +18,7 @@ pub enum Arch {
 }
 
 impl Arch {
-    pub fn new() -> Self {
+    pub fn detect() -> Self {
         if Lasx::is_available() {
             Self::Lasx
         } else if Lsx::is_available() {
@@ -28,7 +28,11 @@ impl Arch {
         }
     }
 
-    pub fn dispatch<Op: WithSimd>(self, op: Op) -> Op::Output {
+    /// Dispatch a function on this [`Arch`]
+    ///
+    /// # Safety
+    /// Required features for the [`Arch`] must be available.
+    pub unsafe fn dispatch<Op: WithSimd>(self, op: Op) -> Op::Output {
         match self {
             Arch::Scalar => <Fallback as Simd>::vectorize(op),
             Arch::Lsx => <Lsx as Simd>::vectorize(op),
@@ -39,6 +43,6 @@ impl Arch {
 
 impl Default for Arch {
     fn default() -> Self {
-        Self::new()
+        Self::detect()
     }
 }

--- a/src/backend/arch/scalar.rs
+++ b/src/backend/arch/scalar.rs
@@ -10,11 +10,15 @@ pub enum Arch {
 }
 
 impl Arch {
-    pub fn new() -> Self {
+    pub fn detect() -> Self {
         Self::Scalar
     }
 
-    pub fn dispatch<Op: WithSimd>(self, op: Op) -> Op::Output {
+    /// Dispatch a function on this [`Arch`]
+    ///
+    /// # Safety
+    /// Required features for the [`Arch`] must be available.
+    pub unsafe fn dispatch<Op: WithSimd>(self, op: Op) -> Op::Output {
         match self {
             Arch::Scalar => <crate::scalar::Fallback as Simd>::vectorize(op),
         }
@@ -23,6 +27,6 @@ impl Arch {
 
 impl Default for Arch {
     fn default() -> Self {
-        Self::new()
+        Self::detect()
     }
 }

--- a/src/backend/arch/wasm32.rs
+++ b/src/backend/arch/wasm32.rs
@@ -13,7 +13,7 @@ pub enum Arch {
 }
 
 impl Arch {
-    pub fn new() -> Self {
+    pub fn detect() -> Self {
         #[cfg(relaxed_simd)]
         if wasm32::Simd128Relaxed::is_available() {
             return Self::Simd128Relaxed;
@@ -25,7 +25,11 @@ impl Arch {
         }
     }
 
-    pub fn dispatch<Op: WithSimd>(self, op: Op) -> Op::Output {
+    /// Dispatch a function on this [`Arch`]
+    ///
+    /// # Safety
+    /// Required features for the [`Arch`] must be available.
+    pub unsafe fn dispatch<Op: WithSimd>(self, op: Op) -> Op::Output {
         match self {
             Arch::Scalar => <Fallback as Simd>::vectorize(op),
             #[cfg(relaxed_simd)]
@@ -37,6 +41,6 @@ impl Arch {
 
 impl Default for Arch {
     fn default() -> Self {
-        Self::new()
+        Self::detect()
     }
 }

--- a/src/backend/arch/x86.rs
+++ b/src/backend/arch/x86.rs
@@ -16,7 +16,7 @@ pub enum Arch {
 }
 
 impl Arch {
-    pub fn new() -> Self {
+    pub fn detect() -> Self {
         #[cfg(avx512_fp16)]
         if x86::V4FP16::is_available() {
             return Self::V4FP16;
@@ -35,7 +35,11 @@ impl Arch {
         }
     }
 
-    pub fn dispatch<Op: WithSimd>(self, op: Op) -> Op::Output {
+    /// Dispatch a function on this [`Arch`]
+    ///
+    /// # Safety
+    /// Required features for the [`Arch`] must be available.
+    pub unsafe fn dispatch<Op: WithSimd>(self, op: Op) -> Op::Output {
         match self {
             Arch::Scalar => <Fallback as Simd>::vectorize(op),
             Arch::V2 => <x86::V2 as Simd>::vectorize(op),
@@ -50,6 +54,6 @@ impl Arch {
 
 impl Default for Arch {
     fn default() -> Self {
-        Self::new()
+        Self::detect()
     }
 }

--- a/src/backend/loong64/lasx.rs
+++ b/src/backend/loong64/lasx.rs
@@ -136,7 +136,7 @@ impl Simd for Lasx {
     impl_reduce_scalar!(reduce_min, min, u8, i8, u16, i16, u32, i32, u64, i64, f16, f32, f64);
     impl_reduce_scalar!(reduce_max, max, u8, i8, u16, i16, u32, i32, u64, i64, f16, f32, f64);
 
-    fn vectorize<Op: WithSimd>(op: Op) -> Op::Output {
+    unsafe fn vectorize<Op: WithSimd>(op: Op) -> Op::Output {
         struct Impl<Op> {
             op: Op,
         }

--- a/src/backend/loong64/lsx.rs
+++ b/src/backend/loong64/lsx.rs
@@ -139,7 +139,7 @@ impl Simd for Lsx {
     impl_reduce_scalar!(reduce_min, min, u8, i8, u16, i16, u32, i32, u64, i64, f16, f32, f64);
     impl_reduce_scalar!(reduce_max, max, u8, i8, u16, i16, u32, i32, u64, i64, f16, f32, f64);
 
-    fn vectorize<Op: WithSimd>(op: Op) -> Op::Output {
+    unsafe fn vectorize<Op: WithSimd>(op: Op) -> Op::Output {
         struct Impl<Op> {
             op: Op,
         }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -16,7 +16,7 @@ use half::{bf16, f16};
 use paste::paste;
 
 mod arch;
-pub use arch::{Arch, WithSimd};
+pub use arch::{Arch, AutoArch, WithSimd};
 
 moddef::moddef!(
     pub(crate) mod {
@@ -231,7 +231,12 @@ pub trait Simd: Sized + seal::Sealed + 'static {
             _ty: PhantomData,
         }
     }
-    fn vectorize<Op: WithSimd>(op: Op) -> Op::Output;
+
+    /// Run a function on on this [`Simd`] arch.
+    ///
+    /// # Safety
+    /// Required features must be available.
+    unsafe fn vectorize<Op: WithSimd>(op: Op) -> Op::Output;
 
     /// Store a `Mask8` as a set of booleans of `lanes8` width, converting as
     /// necessary.

--- a/src/backend/scalar.rs
+++ b/src/backend/scalar.rs
@@ -194,7 +194,8 @@ impl<const LANES: usize> MaskOps for ScalarMask<LANES> {}
 #[inline(always)]
 unsafe fn mask_store_as_bool<const LANES: usize>(out: *mut bool, mask: ScalarMask<LANES>) {
     for (i, lane) in mask.0.into_iter().enumerate() {
-        // there is no `as bool` in Rust, `!= 0` is the canonical conversion rustc suggests
+        // there is no `as bool` in Rust, `!= 0` is the canonical conversion rustc
+        // suggests
         unsafe { write(out.add(i), lane & 1 != 0) };
     }
 }
@@ -334,7 +335,7 @@ impl Simd for Fallback {
     impl_reduce_scalar!(reduce_min, min, u8, i8, u16, i16, u32, i32, u64, i64, f16, f32, f64);
     impl_reduce_scalar!(reduce_max, max, u8, i8, u16, i16, u32, i32, u64, i64, f16, f32, f64);
 
-    fn vectorize<Op: WithSimd>(op: Op) -> Op::Output {
+    unsafe fn vectorize<Op: WithSimd>(op: Op) -> Op::Output {
         op.with_simd::<Self>()
     }
 

--- a/src/backend/wasm32.rs
+++ b/src/backend/wasm32.rs
@@ -204,12 +204,12 @@ impl Fma for FallbackFma {
 }
 
 trait Simd128Run {
-    fn run_vectorized<F: NullaryFnOnce>(f: F) -> F::Output;
+    unsafe fn run_vectorized<F: NullaryFnOnce>(f: F) -> F::Output;
 }
 
 impl Simd128Run for Simd128Fallback {
     #[inline(always)]
-    fn run_vectorized<F: NullaryFnOnce>(f: F) -> F::Output {
+    unsafe fn run_vectorized<F: NullaryFnOnce>(f: F) -> F::Output {
         Simd128Fallback::run_vectorized(f)
     }
 }
@@ -275,7 +275,7 @@ where
     impl_reduce_scalar!(reduce_min, min, u8, i8, u16, i16, u32, i32, u64, i64, f16, f32, f64);
     impl_reduce_scalar!(reduce_max, max, u8, i8, u16, i16, u32, i32, u64, i64, f16, f32, f64);
 
-    fn vectorize<Op: WithSimd>(op: Op) -> Op::Output {
+    unsafe fn vectorize<Op: WithSimd>(op: Op) -> Op::Output {
         struct Impl<Op, F> {
             op: Op,
             _fma: PhantomData<F>,

--- a/src/backend/x86/v2.rs
+++ b/src/backend/x86/v2.rs
@@ -118,7 +118,7 @@ impl Simd for V2 {
     impl_reduce_scalar!(reduce_min, min, u8, i8, u16, i16, u32, i32, u64, i64, f16, f32, f64);
     impl_reduce_scalar!(reduce_max, max, u8, i8, u16, i16, u32, i32, u64, i64, f16, f32, f64);
 
-    fn vectorize<Op: WithSimd>(op: Op) -> Op::Output {
+    unsafe fn vectorize<Op: WithSimd>(op: Op) -> Op::Output {
         struct Impl<Op> {
             op: Op,
         }

--- a/src/backend/x86/v3.rs
+++ b/src/backend/x86/v3.rs
@@ -126,7 +126,7 @@ impl Simd for V3 {
     impl_reduce_scalar!(reduce_min, min, u8, i8, u16, i16, u32, i32, u64, i64, f16, f32, f64);
     impl_reduce_scalar!(reduce_max, max, u8, i8, u16, i16, u32, i32, u64, i64, f16, f32, f64);
 
-    fn vectorize<Op: WithSimd>(op: Op) -> Op::Output {
+    unsafe fn vectorize<Op: WithSimd>(op: Op) -> Op::Output {
         struct Impl<Op> {
             op: Op,
         }

--- a/src/backend/x86/v4.rs
+++ b/src/backend/x86/v4.rs
@@ -378,7 +378,7 @@ where
     delegate_fp16!(reduce reduce_add, reduce_min, reduce_max);
     delegate_fp16!(cmp equals, less_than, less_than_or_equal, greater_than_or_equal, greater_than);
 
-    fn vectorize<Op: WithSimd>(op: Op) -> Op::Output {
+    unsafe fn vectorize<Op: WithSimd>(op: Op) -> Op::Output {
         struct Impl<Op, FP16: FP16Ext> {
             op: Op,
             _fp16: PhantomData<FP16>,
@@ -570,12 +570,12 @@ where
 }
 
 trait V4Run {
-    fn run_vectorized<F: NullaryFnOnce>(f: F) -> F::Output;
+    unsafe fn run_vectorized<F: NullaryFnOnce>(f: F) -> F::Output;
 }
 
 impl V4Run for V4 {
     #[inline(always)]
-    fn run_vectorized<F: NullaryFnOnce>(f: F) -> F::Output {
+    unsafe fn run_vectorized<F: NullaryFnOnce>(f: F) -> F::Output {
         V4::run_vectorized(f)
     }
 }
@@ -583,7 +583,7 @@ impl V4Run for V4 {
 #[cfg(avx512_fp16)]
 impl V4Run for V4FP16 {
     #[inline(always)]
-    fn run_vectorized<F: NullaryFnOnce>(f: F) -> F::Output {
+    unsafe fn run_vectorized<F: NullaryFnOnce>(f: F) -> F::Output {
         V4FP16::run_vectorized(f)
     }
 }

--- a/src/tests/arithmetic.rs
+++ b/src/tests/arithmetic.rs
@@ -119,7 +119,7 @@ macro_rules! testgen_fma {
                     .map(|((a, b), c)| a * b + c)
                     .collect::<Vec<_>>();
                 #[cfg(x86)]
-                {
+                unsafe {
                     use crate::backend::x86::*;
                     #[cfg(avx512_fp16)]
                     if V4FP16::is_available() {
@@ -141,7 +141,7 @@ macro_rules! testgen_fma {
                     }
                 }
                 #[cfg(aarch64)]
-                {
+                unsafe {
                     use crate::backend::aarch64::*;
                     #[cfg(feature = "fp16")]
                     if NeonFP16::is_available() {
@@ -154,7 +154,7 @@ macro_rules! testgen_fma {
                     }
                 }
                 #[cfg(loong64)]
-                {
+                unsafe {
                     use crate::backend::loong64::*;
                     if Lasx::is_available() {
                         let out = Lasx::run_vectorized(|| [<$test_fn _impl>]::<Lasx, $ty>(&a, &b, &c));
@@ -166,7 +166,7 @@ macro_rules! testgen_fma {
                     }
                 }
                 #[cfg(wasm32)]
-                {
+                unsafe {
                     use crate::backend::wasm32;
                     #[cfg(relaxed_simd)]
                     if wasm32::Simd128Relaxed::is_available() {

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -60,7 +60,7 @@ macro_rules! testgen_binop {
                     .map(|(a, b)| $reference(a, b))
                     .collect::<Vec<_>>();
                 #[cfg(x86)]
-                {
+                unsafe {
                     use $crate::backend::x86::*;
                     #[cfg(avx512_fp16)]
                     if V4FP16::is_available() {
@@ -82,7 +82,7 @@ macro_rules! testgen_binop {
                     }
                 }
                 #[cfg(aarch64)]
-                {
+                unsafe {
                     use $crate::backend::aarch64::*;
                     #[cfg(feature = "fp16")]
                     if NeonFP16::is_available() {
@@ -95,7 +95,7 @@ macro_rules! testgen_binop {
                     }
                 }
                 #[cfg(loong64)]
-                {
+                unsafe {
                     use $crate::backend::loong64::*;
                     if Lasx::is_available() {
                         let out = Lasx::run_vectorized(|| [<$test_fn _impl>]::<Lasx, $ty>(&lhs, &rhs));
@@ -107,7 +107,7 @@ macro_rules! testgen_binop {
                     }
                 }
                 #[cfg(wasm32)]
-                {
+                unsafe {
                     use crate::backend::wasm32;
                     #[cfg(relaxed_simd)]
                     if wasm32::Simd128Relaxed::is_available() {
@@ -204,7 +204,7 @@ macro_rules! testgen_unop {
                 let a = $crate::tests::random::<$ty>(NumCast::from($lo).unwrap(), NumCast::from($hi).unwrap());
                 let out_ref = a.iter().map(|a| $ty::$reference(*a)).collect::<Vec<_>>();
                 #[cfg(x86)]
-                {
+                unsafe {
                     use $crate::backend::x86::*;
                     #[cfg(avx512_fp16)]
                     if V4FP16::is_available() {
@@ -226,7 +226,7 @@ macro_rules! testgen_unop {
                     }
                 }
                 #[cfg(aarch64)]
-                {
+                unsafe {
                     use $crate::backend::aarch64::*;
                     #[cfg(feature = "fp16")]
                     if NeonFP16::is_available() {
@@ -239,7 +239,7 @@ macro_rules! testgen_unop {
                     }
                 }
                 #[cfg(loong64)]
-                {
+                unsafe {
                     use $crate::backend::loong64::*;
                     if Lasx::is_available() {
                         let out = Lasx::run_vectorized(|| [<$test_fn _impl>]::<Lasx, $ty>(&a));
@@ -251,7 +251,7 @@ macro_rules! testgen_unop {
                     }
                 }
                 #[cfg(wasm32)]
-                {
+                unsafe {
                     use crate::backend::wasm32;
                     #[cfg(relaxed_simd)]
                     if wasm32::Simd128Relaxed::is_available() {

--- a/src/tests/ord.rs
+++ b/src/tests/ord.rs
@@ -55,7 +55,7 @@ macro_rules! testgen_cmp {
                     .map(|(a, b)| $ty::$reference(a, b))
                     .collect::<Vec<_>>();
                 #[cfg(x86)]
-                {
+                unsafe {
                     use $crate::backend::x86::*;
                     #[cfg(avx512_fp16)]
                     if V4FP16::is_available() {
@@ -77,7 +77,7 @@ macro_rules! testgen_cmp {
                     }
                 }
                 #[cfg(aarch64)]
-                {
+                unsafe {
                     use $crate::backend::aarch64::*;
                     #[cfg(feature = "fp16")]
                     if NeonFP16::is_available() {
@@ -90,7 +90,7 @@ macro_rules! testgen_cmp {
                     }
                 }
                 #[cfg(loong64)]
-                {
+                unsafe {
                     use $crate::backend::loong64::*;
                     if Lasx::is_available() {
                         let out = Lasx::run_vectorized(|| [<$test_fn _impl>]::<Lasx, $ty>(&lhs, &rhs));
@@ -102,7 +102,7 @@ macro_rules! testgen_cmp {
                     }
                 }
                 #[cfg(wasm32)]
-                {
+                unsafe {
                     use crate::backend::wasm32;
                     #[cfg(relaxed_simd)]
                     if wasm32::Simd128Relaxed::is_available() {
@@ -137,7 +137,7 @@ macro_rules! testgen_min_max {
                     .map(|(a, b)| $ty::$reference(*a, *b))
                     .collect::<Vec<_>>();
                 #[cfg(x86)]
-                {
+                unsafe {
                     use $crate::backend::x86::*;
                     #[cfg(avx512_fp16)]
                     if V4FP16::is_available() {
@@ -159,7 +159,7 @@ macro_rules! testgen_min_max {
                     }
                 }
                 #[cfg(aarch64)]
-                {
+                unsafe {
                     use $crate::backend::aarch64::*;
                     #[cfg(feature = "fp16")]
                     if NeonFP16::is_available() {
@@ -172,7 +172,7 @@ macro_rules! testgen_min_max {
                     }
                 }
                 #[cfg(loong64)]
-                {
+                unsafe {
                     use $crate::backend::loong64::*;
                     if Lasx::is_available() {
                         let out = Lasx::run_vectorized(|| [<$test_fn _impl>]::<Lasx, $ty>(&lhs, &rhs));
@@ -184,7 +184,7 @@ macro_rules! testgen_min_max {
                     }
                 }
                 #[cfg(wasm32)]
-                {
+                unsafe {
                     use crate::backend::wasm32;
                     #[cfg(relaxed_simd)]
                     if wasm32::Simd128Relaxed::is_available() {

--- a/src/tests/reduce.rs
+++ b/src/tests/reduce.rs
@@ -101,7 +101,7 @@ macro_rules! testgen_reduce {
                 let a = $crate::tests::random_of_size::<$ty>(NumCast::from($lo).unwrap(), NumCast::from($hi).unwrap(), $size);
                 let out_ref: [$ty; 1] = [a.iter().copied().fold($default, |a: $ty, b: $ty| a.$reference(b))];
                 #[cfg(x86)]
-                {
+                unsafe {
                     use $crate::backend::x86::*;
                     #[cfg(avx512_fp16)]
                     if V4FP16::is_available() {
@@ -123,7 +123,7 @@ macro_rules! testgen_reduce {
                     }
                 }
                 #[cfg(aarch64)]
-                {
+                unsafe {
                     use $crate::backend::aarch64::*;
                     #[cfg(feature = "fp16")]
                     if NeonFP16::is_available() {
@@ -136,7 +136,7 @@ macro_rules! testgen_reduce {
                     }
                 }
                 #[cfg(loong64)]
-                {
+                unsafe {
                     use $crate::backend::loong64::*;
                     if Lasx::is_available() {
                         let out = Lasx::run_vectorized(|| [<$test_fn _impl>]::<Lasx, $ty>(&a));
@@ -148,7 +148,7 @@ macro_rules! testgen_reduce {
                     }
                 }
                 #[cfg(wasm32)]
-                {
+                unsafe {
                     use crate::backend::wasm32;
                     #[cfg(relaxed_simd)]
                     if wasm32::Simd128Relaxed::is_available() {


### PR DESCRIPTION
Fixes https://github.com/wingertge/macerator/issues/32